### PR TITLE
BI-4032 Fixes for confirm company test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,6 +1249,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
@@ -1373,6 +1379,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.7.tgz",
+      "integrity": "sha512-JSwNPgRYjIC4pIeOqLwWwfGj6iP1n5NE6kNBEbGx2V8H78xCPwx7QpNp9plaI30+W3cFEzJO7BIIsXE+dbtaGg==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.9.tgz",
+      "integrity": "sha512-0BTpWWWAO1+uXaP/oA0KW1eOZv4hc0knhrWowV06Gwwz3kqQxNO98fUFM2e15T+PdPRmOouNFrYvaBgdojPJ3g==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.5",
@@ -10247,7 +10272,7 @@
       "from": "git+ssh://git@github.com/companieshouse/web-security-node.git#0.1.1",
       "requires": {
         "ch-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#a3e0dcc57f91f63803e02ceef2cc5e4038de9a19",
-        "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#fd890c30d4dc253beaa8cd65182962ecb3691c16"
+        "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#3.0.1"
       },
       "dependencies": {
         "ch-logging": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/express": "^4.16.1",
     "@types/jest": "^26.0.0",
     "@types/nunjucks": "^3.1.1",
+    "@types/supertest": "^2.0.9",
     "jest": "^26.0.1",
     "node-sass": "^4.14.1",
     "nodemon": "^2.0.3",

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -30,4 +30,4 @@ const route = async (req: Request, res: Response, next: NextFunction): Promise<v
     return res.redirect(OBJECTIONS_CONFIRM_COMPANY);
 };
 
-export default [route];
+export default route;

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -1,7 +1,7 @@
 import { Session } from "ch-node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import { OBJECTIONS_COMPANY_PROFILE } from "../constants";
-import { ObjectionCompanyProfile } from "../model/objection.company.profile";
+import ObjectionCompanyProfile from "../model/objection.company.profile";
 import { OBJECTIONS_CONFIRM_COMPANY } from "../model/page.urls";
 import { getCompanyProfile } from "../services/company.profile.service";
 import { addToObjectionsSession, createObjectionsSession, getValidAccessToken } from "../services/objections.session.service";

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import ObjectionCompanyProfile from "model/objection.company.profile";
 import { OBJECTIONS_COMPANY_PROFILE } from "../constants";
 import { Templates } from "../model/template.paths";
 import { getValueFromObjectionsSession } from "../services/objections.session.service";
@@ -11,16 +12,19 @@ import logger from "../utils/logger";
  * @param next
  */
 
-export const route = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+export const route = (req: Request, res: Response, next: NextFunction) => {
     if (req.session && req.session.data) {
-        const company: string = getValueFromObjectionsSession(req.session, OBJECTIONS_COMPANY_PROFILE);
+        const company: ObjectionCompanyProfile = getValueFromObjectionsSession(req.session, OBJECTIONS_COMPANY_PROFILE);
         return res.render(Templates.CONFIRM_COMPANY, {
             company,
             templateName: Templates.CONFIRM_COMPANY,
         });
     } else {
         logger.error("Error displaying company data");
+        // TODO - implement generic error page to be called with next(ERROR())
+        // same as PTF eg next(e)
+        return next();
     }
 };
 
-export default [route];
+export default route;

--- a/src/model/objection.company.profile.ts
+++ b/src/model/objection.company.profile.ts
@@ -1,4 +1,4 @@
-export interface ObjectionCompanyProfile {
+export default interface ObjectionCompanyProfile {
   companyName: string;
   companyNumber: string;
   companyStatus: string;

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -19,6 +19,6 @@ router.get("/", renderTemplate(Templates.INDEX));
 
 router.get(pageURLs.COMPANY_NUMBER, renderTemplate(Templates.COMPANY_NUMBER));
 router.post(pageURLs.COMPANY_NUMBER, ...companyNumberRoute);
-router.get(pageURLs.CONFIRM_COMPANY, ...confirmCompanyRoute);
+router.get(pageURLs.CONFIRM_COMPANY, confirmCompanyRoute);
 
 export default router;

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -18,7 +18,7 @@ const renderTemplate = (template: string) => (req: Request, res: Response) => {
 router.get("/", renderTemplate(Templates.INDEX));
 
 router.get(pageURLs.COMPANY_NUMBER, renderTemplate(Templates.COMPANY_NUMBER));
-router.post(pageURLs.COMPANY_NUMBER, ...companyNumberRoute);
+router.post(pageURLs.COMPANY_NUMBER, companyNumberRoute);
 router.get(pageURLs.CONFIRM_COMPANY, confirmCompanyRoute);
 
 export default router;

--- a/src/services/company.profile.service.ts
+++ b/src/services/company.profile.service.ts
@@ -1,7 +1,7 @@
 import { createApiClient } from "ch-sdk-node";
 import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
 import Resource from "ch-sdk-node/dist/services/resource";
-import { ObjectionCompanyProfile } from "../model/objection.company.profile";
+import ObjectionCompanyProfile from "../model/objection.company.profile";
 import { lookupCompanyStatus, lookupCompanyType } from "../utils/api.enumerations";
 import { formatCHSDateForDisplay } from "../utils/date.formatter";
 import logger from "../utils/logger";

--- a/src/services/objections.session.service.ts
+++ b/src/services/objections.session.service.ts
@@ -1,5 +1,4 @@
 import { Session } from "ch-node-session-handler";
-import { Request } from "express";
 import { OBJECTIONS_SESSION } from "../constants";
 import logger from "../utils/logger";
 

--- a/test/controller/company.number.controller.spec.unit.ts
+++ b/test/controller/company.number.controller.spec.unit.ts
@@ -7,7 +7,7 @@ import request from "supertest";
 import app from "../../src/app";
 import authenticationMiddleware from "../../src/middleware/authentication.middleware";
 import sessionMiddleware from "../../src/middleware/session.middleware";
-import { ObjectionCompanyProfile } from "../../src/model/objection.company.profile";
+import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
 import { COMPANY_NUMBER, OBJECTIONS_COMPANY_NUMBER, OBJECTIONS_CONFIRM_COMPANY } from "../../src/model/page.urls";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
 import { COOKIE_NAME } from "../../src/utils/properties";

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -1,4 +1,4 @@
-export default async () => {
+export default () => {
   process.env.COOKIE_NAME = "cookie_name";
   process.env.COOKIE_DOMAIN = "cookie_domain";
   process.env.COOKIE_SECRET = "123456789012345678901234";

--- a/test/routes/routes.spec.unit.ts
+++ b/test/routes/routes.spec.unit.ts
@@ -1,19 +1,30 @@
 jest.mock("ioredis");
 jest.mock("../../src/middleware/authentication.middleware");
 jest.mock("../../src/middleware/session.middleware");
+jest.mock("../../src/services/objections.session.service");
 
+import { Session } from "ch-node-session-handler/lib/session/model/Session";
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
 import app from "../../src/app";
 import authenticationMiddleware from "../../src/middleware/authentication.middleware";
 import sessionMiddleware from "../../src/middleware/session.middleware";
+import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
+import { getValueFromObjectionsSession } from "../../src/services/objections.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
+
+const mockGetObjectionSessionValue = getValueFromObjectionsSession as jest.Mock;
 
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
 
 const mockSessionMiddleware = sessionMiddleware as jest.Mock;
-mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next() );
+mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+    req.session = {
+        data: {},
+    } as Session;
+    return next();
+});
 
 describe("Basic URL Tests", () => {
 
@@ -43,6 +54,9 @@ describe("Basic URL Tests", () => {
   });
 
   it("should find the confirm company page", async () => {
+    mockGetObjectionSessionValue.mockReset();
+    mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
+
     const response = await request(app)
       .get("/strike-off-objections/confirm-company");
 
@@ -51,3 +65,16 @@ describe("Basic URL Tests", () => {
   });
 
 });
+
+const dummyCompanyProfile: ObjectionCompanyProfile = {
+    address: {
+        line_1: "line1",
+        line_2: "line2",
+        postCode: "post code",
+    },
+    companyName: "Girls school trust",
+    companyNumber: "00006400",
+    companyStatus: "Active",
+    companyType: "limited",
+    incorporationDate: "26 June 1872",
+};

--- a/test/services/objections.session.service.spec.unit.ts
+++ b/test/services/objections.session.service.spec.unit.ts
@@ -8,47 +8,47 @@ const testValue: string = "00006400";
 const accessTokenValue = "tokenABC123";
 
 describe ("objections session service tests", () => {
-    it("should create a new empty objections session", async () => {
+    it("should create a new empty objections session", () => {
         const session: Session = new Session();
         expect(session.data[OBJECTIONS_SESSION]).toBeFalsy();
-        await objectionsSessionService.createObjectionsSession(session);
+        objectionsSessionService.createObjectionsSession(session);
         expect(session.data[OBJECTIONS_SESSION]).toBeTruthy();
     });
 
-    it("should replace an existing objections session if one exists", async () => {
+    it("should replace an existing objections session if one exists", () => {
         const session: Session = new Session();
-        await objectionsSessionService.createObjectionsSession(session);
+        objectionsSessionService.createObjectionsSession(session);
         expect(session.data[OBJECTIONS_SESSION]).toBeTruthy();
         session.data[OBJECTIONS_SESSION][testKey] = testValue;
 
-        await objectionsSessionService.createObjectionsSession(session);
+        objectionsSessionService.createObjectionsSession(session);
         expect(session.data[OBJECTIONS_SESSION][testKey]).toBeFalsy();
     });
 
-    it("should update the objections session successfully", async () => {
+    it("should update the objections session successfully", () => {
         const session: Session = new Session();
-        await objectionsSessionService.createObjectionsSession(session);
+        objectionsSessionService.createObjectionsSession(session);
         expect(session.data[OBJECTIONS_SESSION]).toBeTruthy();
 
-        await objectionsSessionService.addToObjectionsSession(session, testKey, testValue);
+        objectionsSessionService.addToObjectionsSession(session, testKey, testValue);
         expect(session.data[OBJECTIONS_SESSION][testKey]).toEqual(testValue);
 
         const newValue: string = "10";
-        await objectionsSessionService.addToObjectionsSession(session, testKey, newValue);
+        objectionsSessionService.addToObjectionsSession(session, testKey, newValue);
         expect(session.data[OBJECTIONS_SESSION][testKey]).toEqual(newValue);
     });
 
-    it("should retrieve from the objections session successfully", async () => {
+    it("should retrieve from the objections session successfully", () => {
         const session: Session = new Session();
-        await objectionsSessionService.createObjectionsSession(session);
+        objectionsSessionService.createObjectionsSession(session);
         expect(session.data[OBJECTIONS_SESSION]).toBeTruthy();
 
-        await objectionsSessionService.addToObjectionsSession(session, testKey, testValue);
+        objectionsSessionService.addToObjectionsSession(session, testKey, testValue);
         const gotFromSessionValue: string = objectionsSessionService.getValueFromObjectionsSession(session, testKey);
         expect(gotFromSessionValue).toEqual(testValue);
     });
 
-    it("should retieve access token when present in the session", async () => {
+    it("should retieve access token when present in the session", () => {
         const session: Session = new Session();
         session.data = {
             signin_info: {
@@ -62,13 +62,13 @@ describe ("objections session service tests", () => {
         expect(token).toEqual(accessTokenValue);
     });
 
-    it("should receive undefined when token is absent", async () => {
+    it("should receive undefined when token is absent", () => {
         const session: Session = new Session();
         const token: string = getValidAccessToken(session) as string;
         expect(token).toBeUndefined();
     });
 
-    it("should receive undefined when token is empty", async () => {
+    it("should receive undefined when token is empty", () => {
         const session: Session = new Session();
         session.data = {
             signin_info: {

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
   "jsRules": {},
   "rules": {
     "interface-name": false,
+    "no-async-without-await": true,
     "variable-name": [true, "check-format", "allow-leading-underscore"],
     "whitespace": [true,
       "check-branch",


### PR DESCRIPTION
test was hanging due to 2 things:
a) needed to mock redis out with jest.mock("ioredis");
b) the route function was falling into the else block as the session had no data and it needed to return something after it had logged the error otherwise it just hangs. I've added return next() to get the test to pass but unsure if this will work in real life (haven't run it). We need to implement the generic error screen so we can call next(new Error("blah"));  

added the data block to the session in the mock implementation to get past the 'if' in the controller. I'll look into whether we can make that mock importable, but for the time being just do similar in each test.

tidied up a few things, the getDummyProfile function in the test was returning a function which was passed into the template so fixed that.
Removed async off route as I think we only need to use async if we use await inside.
VSCode highlighted the supertest types so added those.
Changed the route from being exported as an array, might need to change it back in future if we want to export a chain of functions.
Made the ObjectionsCompanyProfile interface the default export as it will be the only thing in that file. We can then remove the {} from the import.
