### PR TITLE
OBJ-70 Making the upload file callback function return Promise<void>

### DIFF
--- a/src/controllers/document_upload/document.upload.controller.ts
+++ b/src/controllers/document_upload/document.upload.controller.ts
@@ -105,12 +105,13 @@ export const postContinueButton = async (req: Request, res: Response, next: Next
 const getFileSizeLimitExceededCallback = (req: Request,
                                           res: Response,
                                           uploadResponderStrategy: UploadResponderStrategy,
-                                          attachments: any[]): (filename: string, maxInBytes: number) => void => {
-  return (filename: string, maxInBytes: number) => {
+                                          attachments: any[]):
+                                            (filename: string, maxInBytes: number) => Promise<void> => {
+  return async (filename: string, maxInBytes: number) => {
     const maxInMB: number = getMaxFileSizeInMB(maxInBytes);
     logger.debug("File limit " + maxInMB + "MB reached for file " + filename);
     const errorMsg: string = `${UploadErrorMessages.FILE_TOO_LARGE} ${maxInMB} MB`;
-    return displayError(res, errorMsg, uploadResponderStrategy, attachments);
+    return await displayError(res, errorMsg, uploadResponderStrategy, attachments);
   };
 };
 
@@ -125,7 +126,7 @@ const getFileSizeLimitExceededCallback = (req: Request,
 const getNoFileDataReceivedCallback = (req: Request,
                                        res: Response,
                                        uploadResponderStrategy: UploadResponderStrategy,
-                                       attachments: any[]): (filename: string) => void => {
+                                       attachments: any[]): (filename: string) => Promise<void> => {
   return async (_filename: string) => {
     return await displayError(res, UploadErrorMessages.NO_FILE_CHOSEN, uploadResponderStrategy, attachments);
   };

--- a/src/controllers/document_upload/http.request.file.uploader.ts
+++ b/src/controllers/document_upload/http.request.file.uploader.ts
@@ -16,19 +16,19 @@ export interface UploadFileCallbacks {
    * @param {string} filename of the file being uploaded
    * @param {number} maxSizeBytes the maximum file size allowed in bytes
    */
-  fileSizeLimitExceededCallback: (filename: string, maxSizeBytes: number) => void;
+  fileSizeLimitExceededCallback: (filename: string, maxSizeBytes: number) => Promise<void>;
   /**
    * No file data received
    * @param {string} filename of the file being uploaded
    */
-  noFileDataReceivedCallback: (filename: string) => void;
+  noFileDataReceivedCallback: (filename: string) => Promise<void>;
   /**
    * Upload finished
    * @param {string} filename of the file being uploaded
    * @param {Buffer} fileData the data contained in the file
    * @param {string} mimeType of the file being uploaded
    */
-  uploadFinishedCallback: (filename: string, fileData: Buffer, mimeType: string) => void;
+  uploadFinishedCallback: (filename: string, fileData: Buffer, mimeType: string) => Promise<void>;
 }
 
 /**
@@ -69,9 +69,9 @@ export const uploadFile = (req: Request,
     });
 
     // File on limit event - fired when file size limit is reached
-    fileStream.on("limit", () => {
+    fileStream.on("limit", async () => {
       fileStream.destroy();
-      return callbacks.fileSizeLimitExceededCallback(filename, maxFileSizeBytes);
+      return await callbacks.fileSizeLimitExceededCallback(filename, maxFileSizeBytes);
     });
 
     // File on end event - fired when file has finished - could be if file completed fully or ended
@@ -84,10 +84,10 @@ export const uploadFile = (req: Request,
       const fileData: Buffer = Buffer.concat(chunkArray);
       logger.debug("Total bytes received for " + filename + " = " + fileData.length);
       if (fileData.length === 0) {
-        return callbacks.noFileDataReceivedCallback(filename);
+        return await callbacks.noFileDataReceivedCallback(filename);
       }
 
-      return callbacks.uploadFinishedCallback(filename, fileData, mimeType);
+      return await callbacks.uploadFinishedCallback(filename, fileData, mimeType);
     }); // end fileStream.on("end") event
   }); // end busboy.on("file") event
 


### PR DESCRIPTION
Making the upload file callback function return Promise<void> so they can be called with await in uploadFile. This should mean if they return a reject (as opposed to resolve) the reject error won't be lost.