### PR TITLE
OBJ-12 changed message output for upoad error

### DIFF
--- a/src/model/error.messages.ts
+++ b/src/model/error.messages.ts
@@ -1,6 +1,6 @@
 export enum UploadErrorMessages {
   INVALID_MIME_TYPES = "The selected file must be a JPG, JPEG, ZIP, GIF, PNG, PDF, DOCX or XLSX",
-  NO_DOCUMENTS_ADDED = "You must add a document",
+  NO_DOCUMENTS_ADDED = "Add a document to support your objection",
   NO_FILE_CHOSEN = "You must add a document",
   FILE_TOO_LARGE = "File size must be smaller than",
 }


### PR DESCRIPTION
Comment on Jira ticket:

Oceanne & Emma said the error message is to read:  
‘There is a problem
Add a document to support your objection’

Changed message.