### PR TITLE
Obj 146 sanitise logs

### DIFF
--- a/src/controllers/document_upload/document.upload.controller.ts
+++ b/src/controllers/document_upload/document.upload.controller.ts
@@ -148,7 +148,8 @@ const getUploadFinishedCallback = (req: Request,
   return async (filename: string, fileData: Buffer, mimeType: string) => {
     try {
       const session: Session = req.session as Session;
-      await objectionService.addAttachment(session, fileData, filename);
+      const attachmentId: string = await objectionService.addAttachment(session, fileData, filename);
+      logger.debug(`Attachment with id ${attachmentId} successfully uploaded`);
     } catch (e) {
       logger.error(`User has attempted to upload a ` +
                      `file ${filename}, mime-type: ${mimeType} ` +
@@ -162,7 +163,6 @@ const getUploadFinishedCallback = (req: Request,
       // }
       return uploadResponderStrategy.handleGenericError(res, e, next);
     }
-    logger.debug("Successfully uploaded file " + filename);
     return uploadResponderStrategy.handleSuccess(req, res);
   };
 };

--- a/src/controllers/document_upload/http.request.file.uploader.ts
+++ b/src/controllers/document_upload/http.request.file.uploader.ts
@@ -82,7 +82,7 @@ export const uploadFile = (req: Request,
         return;
       }
       const fileData: Buffer = Buffer.concat(chunkArray);
-      logger.debug("Total bytes received for " + filename + " = " + fileData.length);
+      logger.debug("Total bytes received for file = " + fileData.length);
       if (fileData.length === 0) {
         return await callbacks.noFileDataReceivedCallback(filename);
       }

--- a/src/modules/sdk/objections/service.ts
+++ b/src/modules/sdk/objections/service.ts
@@ -61,7 +61,7 @@ export const addAttachment = async (companyNumber: string,
                                     token: string,
                                     objectionId: string,
                                     attachment: Buffer,
-                                    fileName: string) => {
+                                    fileName: string): Promise<string> => {
 
   const axiosConfig: AxiosRequestConfig = getBaseAxiosRequestConfig(
     HTTP_POST,
@@ -79,7 +79,8 @@ export const addAttachment = async (companyNumber: string,
       ...data.getHeaders(),
     },
   };
-  await makeAPICall(axiosConfig);
+
+  return (await makeAPICall(axiosConfig)).data.id as string;
 };
 
 export const getAttachments = async (companyNumber: string,

--- a/src/services/objection.service.ts
+++ b/src/services/objection.service.ts
@@ -66,7 +66,7 @@ export const addAttachment = async (session: Session,
                                     fileName: string): Promise<string> => {
   const { objectionId, companyNumber, token } = getValuesForApiCall(session);
 
-  logger.info(`Adding a new attachment objection ${objectionId}`);
+  logger.info(`Adding a new attachment to objection ${objectionId}`);
   return await objectionsSdk.addAttachment(companyNumber, token, objectionId, attachment, fileName);
 };
 

--- a/src/services/objection.service.ts
+++ b/src/services/objection.service.ts
@@ -63,11 +63,11 @@ export const submitObjection = (objectionId: string, token: string) => {
 
 export const addAttachment = async (session: Session,
                                     attachment: Buffer,
-                                    fileName: string) => {
+                                    fileName: string): Promise<string> => {
   const { objectionId, companyNumber, token } = getValuesForApiCall(session);
 
-  logger.info(`Adding attachment ${fileName} to objection ${objectionId}`);
-  await objectionsSdk.addAttachment(companyNumber, token, objectionId, attachment, fileName);
+  logger.info(`Adding a new attachment objection ${objectionId}`);
+  return await objectionsSdk.addAttachment(companyNumber, token, objectionId, attachment, fileName);
 };
 
 export const getAttachments = async (session: Session): Promise<Attachment[]> => {

--- a/test/modules/sdk/objections/service.spec.unit.ts
+++ b/test/modules/sdk/objections/service.spec.unit.ts
@@ -90,15 +90,28 @@ describe("objections SDK service unit tests", () => {
   });
 
   it("should call objections API when posting an attachment", async () => {
+
+    const NEW_ATTACHMENT_ID = "f89bc843-bfc2-4121-b00b-0d667947fe5f";
+    mockMakeAPICall.mockResolvedValueOnce({
+      data: {
+        id: NEW_ATTACHMENT_ID,
+      },
+    });
+
     const fileName: string = "fileName";
     const BUFFER = Buffer.from("Buffer");
     const STREAMS_DATA_PARAMATER = "_streams";
-    await objectionsSdk.addAttachment(COMPANY_NUMBER,
+    const attachmentId: string = await objectionsSdk.addAttachment(COMPANY_NUMBER,
         ACCESS_TOKEN,
         OBJECTION_ID,
       BUFFER,
       fileName,
     );
+
+    expect(attachmentId).toBeDefined();
+    expect(typeof attachmentId).toBe("string");
+    expect(attachmentId).toStrictEqual(NEW_ATTACHMENT_ID);
+
     const usedAxiosConfig: AxiosRequestConfig = mockMakeAPICall.mock.calls[0][0];
     const streamZero = usedAxiosConfig.data[STREAMS_DATA_PARAMATER][0];
     expect(streamZero).toContain(fileName);

--- a/test/services/objection.service.spec.unit.ts
+++ b/test/services/objection.service.spec.unit.ts
@@ -69,6 +69,7 @@ const COMPANY_NUMBER = "00006400";
 const NEW_OBJECTION_ID = "7687kjh-33kjkjkjh-hjgh435";
 const REASON = "Owed Money";
 const ATTACHMENT_ID = "file123";
+const NEW_ATTACHMENT_ID = "f89bc843-bfc2-4121-b00b-0d667947fe5f";
 
 describe("objections API service unit tests", () => {
 
@@ -110,14 +111,19 @@ describe("objections API service unit tests", () => {
     expect(patchResult).toBeUndefined();
   });
 
-  it("returns undefined when adding an attachment", () => {
+  it("returns an id when a new attachment is added", async () => {
+    mockAddAttachment.mockResolvedValueOnce(NEW_ATTACHMENT_ID);
+
     const FILE_NAME = "test_file";
     const BUFFER = Buffer.from("Test buffer");
-    const attachmentResult = objectionsService.addAttachment(session,
+    const attachmentId: string = await objectionsService.addAttachment(session,
         BUFFER,
         FILE_NAME );
 
-    expect(attachmentResult).toEqual(Promise.resolve());
+    expect(attachmentId).toBeDefined();
+    expect(typeof attachmentId).toBe("string");
+    expect(attachmentId).toStrictEqual(NEW_ATTACHMENT_ID);
+
     expect(mockAddAttachment).toBeCalledWith(dummyCompanyProfile.companyNumber,
       ACCESS_TOKEN,
       NEW_OBJECTION_ID,


### PR DESCRIPTION
Addresses the specific issue identified in https://companieshouse.atlassian.net/browse/OBJ-146 but I've created a new story for discussion - and implementation - to investigate how we deal with user-entered text appearing in JSON output in the logs. See https://companieshouse.atlassian.net/browse/OBJ-151.