### PR TITLE
Feature/obj 29 fix eslint upload

### DIFF
--- a/src/controllers/document_upload/ajax.upload.responder.strategy.ts
+++ b/src/controllers/document_upload/ajax.upload.responder.strategy.ts
@@ -37,7 +37,7 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
         .then((html: string) =>  this.addReplacementDiv(replacementDivs, html, CHOOSE_FILE_DIV));
       logger.trace("Rendered fragment " + Templates.DOCUMENT_UPLOAD_FILE_PICKER);
 
-      res.send({divs: replacementDivs});
+      return res.send({divs: replacementDivs});
     } catch (e) {
       this.handleGenericError(res, e);
     }
@@ -52,7 +52,7 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
    */
   public handleGenericError = (res: Response, e: Error, _next?: NextFunction) => {
     logger.error(ErrorMessages.ERROR_500 + ": " + e);
-    res.status(500).send({ redirect: pageURLs.OBJECTIONS_ERROR });
+    return res.status(500).send({ redirect: pageURLs.OBJECTIONS_ERROR });
   }
 
   /**
@@ -79,7 +79,7 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
 
       logger.trace("Rendered fragment " + Templates.DOCUMENT_UPLOAD_FILE_PICKER);
 
-      res.send({ divs: replacementDivs });
+      return res.send({ divs: replacementDivs });
     } catch (e) {
       this.handleGenericError(res, e);
     }
@@ -98,7 +98,7 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
    * @param {object} options the data to pass into the template
    */
   private renderFragment = async (res: Response, view: string, options: object): Promise<string> => {
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       res.render(view,
                  options,
                  (err: Error, html: string) => {

--- a/src/controllers/document_upload/ajax.upload.responder.strategy.ts
+++ b/src/controllers/document_upload/ajax.upload.responder.strategy.ts
@@ -24,7 +24,7 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
    * @param {Request} req http request
    * @param {Response} res http response
    */
-  public handleSuccess = async (req: Request, res: Response) => {
+  public handleSuccess = async (req: Request, res: Response): Promise<void> => {
     const session: Session = req.session as Session;
     const replacementDivs: object[] = [];
     try {
@@ -37,9 +37,9 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
         .then((html: string) =>  this.addReplacementDiv(replacementDivs, html, CHOOSE_FILE_DIV));
       logger.trace("Rendered fragment " + Templates.DOCUMENT_UPLOAD_FILE_PICKER);
 
-      return res.send({divs: replacementDivs});
+      res.send({divs: replacementDivs});
     } catch (e) {
-      this.handleGenericError(res, e);
+      await this.handleGenericError(res, e);
     }
   }
 
@@ -50,9 +50,10 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
    * @param {Error} e the error
    * @param {NextFunction} _next the next middleware function
    */
-  public handleGenericError = (res: Response, e: Error, _next?: NextFunction) => {
+  public handleGenericError = (res: Response, e: Error, _next?: NextFunction): Promise<void> => {
     logger.error(ErrorMessages.ERROR_500 + ": " + e);
-    return res.status(500).send({ redirect: pageURLs.OBJECTIONS_ERROR });
+    res.status(500).send({ redirect: pageURLs.OBJECTIONS_ERROR });
+    return Promise.resolve();
   }
 
   /**
@@ -63,7 +64,7 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
    */
   public handleGovUKError = async (res: Response,
                                    errorData: GovUkErrorData,
-                                   attachments: Attachment[]) => {
+                                   attachments: Attachment[]): Promise<void> => {
     const replacementDivs: object[] = [];
 
     try {
@@ -79,9 +80,9 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
 
       logger.trace("Rendered fragment " + Templates.DOCUMENT_UPLOAD_FILE_PICKER);
 
-      return res.send({ divs: replacementDivs });
+      res.send({ divs: replacementDivs });
     } catch (e) {
-      this.handleGenericError(res, e);
+      await this.handleGenericError(res, e);
     }
   }
 
@@ -97,8 +98,8 @@ export class AjaxUploadResponderStrategy implements UploadResponderStrategy {
    * @param {string} view the name of the template
    * @param {object} options the data to pass into the template
    */
-  private renderFragment = async (res: Response, view: string, options: object): Promise<string> => {
-    return await new Promise((resolve, reject) => {
+  private renderFragment = (res: Response, view: string, options: object): Promise<string> => {
+    return new Promise((resolve, reject) => {
       res.render(view,
                  options,
                  (err: Error, html: string) => {

--- a/src/controllers/document_upload/document.upload.controller.ts
+++ b/src/controllers/document_upload/document.upload.controller.ts
@@ -84,11 +84,11 @@ export const postContinueButton = async (req: Request, res: Response, next: Next
     attachments = await objectionService.getAttachments(req.session as Session);
   } catch (e) {
     logger.errorRequest(req, `Error thrown calling objection.service.getAttachments - ${e}`);
-    return uploadResponderStrategy.handleGenericError(res, e, next);
+    return await uploadResponderStrategy.handleGenericError(res, e, next);
   }
 
   if (attachments && attachments.length === 0) {
-    return displayError(res, UploadErrorMessages.NO_DOCUMENTS_ADDED, uploadResponderStrategy, attachments);
+    return await displayError(res, UploadErrorMessages.NO_DOCUMENTS_ADDED, uploadResponderStrategy, attachments);
   }
 
   res.redirect(OBJECTIONS_CHECK_YOUR_ANSWERS);
@@ -158,11 +158,11 @@ const getUploadFinishedCallback = (req: Request,
                      `of size ${fileData.length} bytes. The api has returned the error: ${e.message}`);
 
       if (e.status === HttpStatusCodes.UNSUPPORTED_MEDIA_TYPE) {
-        return displayError(res, UploadErrorMessages.INVALID_MIME_TYPES, uploadResponderStrategy, attachments);
+        return await displayError(res, UploadErrorMessages.INVALID_MIME_TYPES, uploadResponderStrategy, attachments);
       }
-      return uploadResponderStrategy.handleGenericError(res, e, next);
+      return await uploadResponderStrategy.handleGenericError(res, e, next);
     }
-    return uploadResponderStrategy.handleSuccess(req, res);
+    return await uploadResponderStrategy.handleSuccess(req, res);
   };
 };
 

--- a/src/controllers/document_upload/document.upload.controller.ts
+++ b/src/controllers/document_upload/document.upload.controller.ts
@@ -1,5 +1,6 @@
 import { Session } from "ch-node-session-handler";
 import { NextFunction, Request, Response } from "express";
+import { promisify } from "util";
 import { HttpStatusCodes, UploadErrorMessages } from "../../model/error.messages";
 import { createGovUkErrorData, GovUkErrorData } from "../../model/govuk.error.data";
 import { OBJECTIONS_CHECK_YOUR_ANSWERS } from "../../model/page.urls";
@@ -61,8 +62,8 @@ export const postFile = async (req: Request, res: Response, next: NextFunction) 
   }
 
   const uploadCallbacks: UploadFileCallbacks = {
-    fileSizeLimitExceededCallback: getFileSizeLimitExceededCallback(req, res, uploadResponderStrategy, attachments),
-    noFileDataReceivedCallback: getNoFileDataReceivedCallback(req, res, uploadResponderStrategy, attachments),
+    fileSizeLimitExceededCallback: promisify(getFileSizeLimitExceededCallback(req, res, uploadResponderStrategy, attachments)),
+    noFileDataReceivedCallback: promisify(getNoFileDataReceivedCallback(req, res, uploadResponderStrategy, attachments)),
     uploadFinishedCallback: getUploadFinishedCallback(req, res, next, uploadResponderStrategy, attachments),
   };
   const maxFileSizeBytes: number = parseInt(MAX_FILE_SIZE_BYTES, 10);
@@ -106,12 +107,12 @@ const getFileSizeLimitExceededCallback = (req: Request,
                                           res: Response,
                                           uploadResponderStrategy: UploadResponderStrategy,
                                           attachments: Attachment[]):
-                                            (filename: string, maxInBytes: number) => Promise<void> => {
-  return async (filename: string, maxInBytes: number) => {
+                                            (filename: string, maxInBytes: number) => void => {
+  return (filename: string, maxInBytes: number) => {
     const maxInMB: number = getMaxFileSizeInMB(maxInBytes);
     logger.debug("File limit " + maxInMB + "MB reached for file " + filename);
     const errorMsg: string = `${UploadErrorMessages.FILE_TOO_LARGE} ${maxInMB} MB`;
-    return await displayError(res, errorMsg, uploadResponderStrategy, attachments);
+    return displayError(res, errorMsg, uploadResponderStrategy, attachments);
   };
 };
 
@@ -126,9 +127,9 @@ const getFileSizeLimitExceededCallback = (req: Request,
 const getNoFileDataReceivedCallback = (req: Request,
                                        res: Response,
                                        uploadResponderStrategy: UploadResponderStrategy,
-                                       attachments: Attachment[]): (filename: string) => Promise<void> => {
-  return async (_filename: string) => {
-    return await displayError(res, UploadErrorMessages.NO_FILE_CHOSEN, uploadResponderStrategy, attachments);
+                                       attachments: Attachment[]): (filename: string) => void => {
+  return (_filename: string) => {
+    return displayError(res, UploadErrorMessages.NO_FILE_CHOSEN, uploadResponderStrategy, attachments);
   };
 };
 
@@ -158,7 +159,7 @@ const getUploadFinishedCallback = (req: Request,
                      `of size ${fileData.length} bytes. The api has returned the error: ${e.message}`);
 
       if (e.status === HttpStatusCodes.UNSUPPORTED_MEDIA_TYPE) {
-        return await displayError(res, UploadErrorMessages.INVALID_MIME_TYPES, uploadResponderStrategy, attachments);
+        return displayError(res, UploadErrorMessages.INVALID_MIME_TYPES, uploadResponderStrategy, attachments);
       }
       return uploadResponderStrategy.handleGenericError(res, e, next);
     }
@@ -173,10 +174,10 @@ const getUploadFinishedCallback = (req: Request,
  * @param {UploadResponderStrategy} uploadResponderStrategy the strategy for responding to requests
  * @param {Attachment[]} attachments the list of attachments
  */
-const displayError = async (res: Response,
-                            errorMessage: string,
-                            uploadResponderStrategy: UploadResponderStrategy,
-                            attachments: Attachment[]) => {
+const displayError = (res: Response,
+                      errorMessage: string,
+                      uploadResponderStrategy: UploadResponderStrategy,
+                      attachments: Attachment[]) => {
   const documentUploadErrorData: GovUkErrorData =
     createGovUkErrorData(errorMessage, "#file-upload", true, "");
   return uploadResponderStrategy.handleGovUKError(res, documentUploadErrorData, attachments);
@@ -185,7 +186,7 @@ const displayError = async (res: Response,
 /**
  * Gets max file size in MB rounded down to nearest whole number
  * @param {number} maxSizeInBytes the max size allowed in bytes
- * @returns number max size in MB
+ * @returns {number} max size in MB
  */
 const getMaxFileSizeInMB = (maxSizeInBytes: number): number => {
   return Math.floor(maxSizeInBytes / (1024 * 1024));

--- a/src/controllers/document_upload/document.upload.controller.ts
+++ b/src/controllers/document_upload/document.upload.controller.ts
@@ -179,7 +179,7 @@ const displayError = async (res: Response,
                             attachments: Attachment[]) => {
   const documentUploadErrorData: GovUkErrorData =
     createGovUkErrorData(errorMessage, "#file-upload", true, "");
-  await uploadResponderStrategy.handleGovUKError(res, documentUploadErrorData, attachments);
+  return await uploadResponderStrategy.handleGovUKError(res, documentUploadErrorData, attachments);
 };
 
 /**

--- a/src/controllers/document_upload/html.upload.responder.strategy.ts
+++ b/src/controllers/document_upload/html.upload.responder.strategy.ts
@@ -15,7 +15,7 @@ export class HtmlUploadResponderStrategy implements UploadResponderStrategy {
    * @param {Request} req http request
    * @param {Response} res http response
    */
-  public handleSuccess = async (req: Request, res: Response) => {
+  public handleSuccess = (req: Request, res: Response) => {
     return res.redirect(OBJECTIONS_DOCUMENT_UPLOAD);
   }
 

--- a/src/controllers/document_upload/html.upload.responder.strategy.ts
+++ b/src/controllers/document_upload/html.upload.responder.strategy.ts
@@ -15,8 +15,8 @@ export class HtmlUploadResponderStrategy implements UploadResponderStrategy {
    * @param {Request} req http request
    * @param {Response} res http response
    */
-  public handleSuccess = (req: Request, res: Response) => {
-    return res.redirect(OBJECTIONS_DOCUMENT_UPLOAD);
+  public handleSuccess = (req: Request, res: Response): Promise<void> => {
+    return Promise.resolve(res.redirect(OBJECTIONS_DOCUMENT_UPLOAD));
   }
 
   /**
@@ -25,10 +25,11 @@ export class HtmlUploadResponderStrategy implements UploadResponderStrategy {
    * @param {Error} e the error
    * @param {NextFunction} next the next middleware function
    */
-  public handleGenericError = (res: Response, e: Error, next?: NextFunction) => {
+  public handleGenericError = (res: Response, e: Error, next?: NextFunction): Promise<void> => {
     if (next) {
-      return next(e);
+      return Promise.resolve(next(e));
     }
+    return Promise.resolve();
   }
 
   /**
@@ -37,12 +38,14 @@ export class HtmlUploadResponderStrategy implements UploadResponderStrategy {
    * @param {GovUkErrorData} errorData the error information to display
    * @param {Attachment[]} attachments the list of uploaded attachments
    */
-  public handleGovUKError = (res: Response, errorData: GovUkErrorData, attachments: Attachment[]) => {
-    return res.render(Templates.DOCUMENT_UPLOAD, {
-      attachments,
-      documentUploadErr: errorData,
-      errorList: [errorData],
-      templateName: Templates.DOCUMENT_UPLOAD,
-    });
+  public handleGovUKError = (res: Response, errorData: GovUkErrorData, attachments: Attachment[]): Promise<void> => {
+    return Promise.resolve(
+      res.render(Templates.DOCUMENT_UPLOAD, {
+        attachments,
+        documentUploadErr: errorData,
+        errorList: [errorData],
+        templateName: Templates.DOCUMENT_UPLOAD,
+      })
+    );
   }
 }

--- a/src/controllers/document_upload/upload.responder.strategy.ts
+++ b/src/controllers/document_upload/upload.responder.strategy.ts
@@ -6,7 +6,7 @@ import { GovUkErrorData } from "../../model/govuk.error.data";
  * to respond to the client in different ways.
  */
 export interface UploadResponderStrategy {
-  handleSuccess(req: Request, res: Response): void;
-  handleGenericError(res: Response, e: Error, next?: NextFunction): void;
-  handleGovUKError(res: Response, errorData: GovUkErrorData, attachments: any[]): void;
+  handleSuccess(req: Request, res: Response): Promise<void>;
+  handleGenericError(res: Response, e: Error, next?: NextFunction): Promise<void>;
+  handleGovUKError(res: Response, errorData: GovUkErrorData, attachments: any[]): Promise<void>;
 }

--- a/views/check-your-answers.html
+++ b/views/check-your-answers.html
@@ -7,7 +7,7 @@
 {% block backLink %}
   {{ govukBackLink({
     text: "Back",
-    href: "/document-upload"
+    href: "/strike-off-objections/document-upload"
   }) }}
 {% endblock %}
 
@@ -15,7 +15,7 @@
   <ul class="govuk-list govuk-list--bullet">
   {% for attachment in objection.attachments | reverse %}
     <li>
-      <a href="#"" class="govuk-link">{{ attachment.name }}</a>
+      <a href="#" class="govuk-link">{{ attachment.name }}</a>
     </li>
   {% endfor %}
   </ul>


### PR DESCRIPTION
eslint highlighted some async await issues in the uploader.
I've made the strategy interface functions return promises as the eslint issues arose due to the ajax implementation using async / promises and the html version didn't.
This change forces all functions implemented in the strategy interface to return promises.

Also spotted a couple of errors in the check-your-answers page (back link and extra quotation)