### PR TITLE
Moving create objection call to confirm company post method

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -38,16 +38,14 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
   const session: Session = req.session as Session
-  if (session) {
-    try {
-      const token: string = retrieveAccessTokenFromSession(session);
-      const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
-      const objectionId = await createNewObjection(company.companyNumber, token);
-      addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
-      return res.redirect(OBJECTIONS_ENTER_INFORMATION);
-    } catch (e) {
-        return next(e);
-      }
+  try {
+    const token: string = retrieveAccessTokenFromSession(session);
+    const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
+    const objectionId = await createNewObjection(company.companyNumber, token);
+    addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
+    return res.redirect(OBJECTIONS_ENTER_INFORMATION);
+  } catch (e) {
+    return next(e);
   }
 };
 

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -1,7 +1,15 @@
+import { Session } from "ch-node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import ObjectionCompanyProfile from "model/objection.company.profile";
+import { SESSION_OBJECTION_ID } from "../constants";
+import { OBJECTIONS_ENTER_INFORMATION } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
-import { retrieveCompanyProfileFromObjectionSession } from "../services/objection.session.service";
+import { createNewObjection } from "../services/objection.service";
+import {
+  addToObjectionSession,
+  retrieveAccessTokenFromSession,
+  retrieveCompanyProfileFromObjectionSession
+} from "../services/objection.session.service";
 import logger from "../utils/logger";
 
 /**
@@ -27,3 +35,19 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
   return next(new Error("No Session present"));
 };
+
+export const post = async (req: Request, res: Response, next: NextFunction) => {
+  const session: Session = req.session as Session
+  if (session) {
+    try {
+      const token: string = retrieveAccessTokenFromSession(session);
+      const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
+      const objectionId = await createNewObjection(company.companyNumber, token);
+      addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
+      return res.redirect(OBJECTIONS_ENTER_INFORMATION);
+    } catch (e) {
+        return next(e);
+      }
+  }
+};
+

--- a/src/controllers/enter.information.controller.ts
+++ b/src/controllers/enter.information.controller.ts
@@ -4,24 +4,14 @@ import ObjectionCompanyProfile from "model/objection.company.profile";
 import { SESSION_OBJECTION_ID } from "../constants";
 import { OBJECTIONS_DOCUMENT_UPLOAD } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
-import { createNewObjection, updateObjectionReason } from "../services/objection.service";
+import { updateObjectionReason } from "../services/objection.service";
 import {
-  addToObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
   retrieveFromObjectionSession,
 } from "../services/objection.session.service";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
-  const session: Session = req.session as Session;
-  const token: string = retrieveAccessTokenFromSession(session);
-
-  const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
-
-  const objectionId: string = await createNewObjection(company.companyNumber, token);
-
-  addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
-
   return res.render(Templates.ENTER_INFORMATION, {
     templateName: Templates.ENTER_INFORMATION,
   });

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -29,6 +29,7 @@ router.get(pageURLs.COMPANY_NUMBER, renderTemplate(Templates.COMPANY_NUMBER));
 router.post(pageURLs.COMPANY_NUMBER, companyNumberRoute.post);
 
 router.get(pageURLs.CONFIRM_COMPANY, confirmCompanyRoute.get);
+router.post(pageURLs.CONFIRM_COMPANY, confirmCompanyRoute.post);
 
 router.get(pageURLs.NOTICE_EXPIRED, noticeExpiredRoute.get);
 

--- a/test/controller/confirm.company.spec.unit.ts
+++ b/test/controller/confirm.company.spec.unit.ts
@@ -2,6 +2,7 @@ jest.mock("ioredis");
 jest.mock("../../src/middleware/authentication.middleware");
 jest.mock("../../src/middleware/session.middleware");
 jest.mock("../../src/services/objection.session.service");
+jest.mock("../../src/services/objection.service");
 jest.mock("../../src/middleware/objection.session.middleware");
 
 import { Session } from "ch-node-session-handler/lib/session/model/Session";
@@ -13,7 +14,10 @@ import authenticationMiddleware from "../../src/middleware/authentication.middle
 import objectionSessionMiddleware from "../../src/middleware/objection.session.middleware";
 import sessionMiddleware from "../../src/middleware/session.middleware";
 import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
-import { OBJECTIONS_CONFIRM_COMPANY } from "../../src/model/page.urls";
+import {
+  OBJECTIONS_CONFIRM_COMPANY,
+  OBJECTIONS_ENTER_INFORMATION
+} from "../../src/model/page.urls";
 import { createNewObjection } from "../../src/services/objection.service";
 import {
   addToObjectionSession,
@@ -22,7 +26,6 @@ import {
 import { COOKIE_NAME } from "../../src/utils/properties";
 
 const OBJECTION_ID = "123456";
-
 const SESSION: Session = {
   data: {},
 } as Session;
@@ -34,9 +37,7 @@ mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, ne
 
 const mockSessionMiddleware = sessionMiddleware as jest.Mock;
 mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
-  req.session = {
-    data: {},
-  } as Session;
+  req.session = SESSION
   return next();
 });
 
@@ -57,7 +58,7 @@ const mockCreateNewObjection = createNewObjection as jest.Mock;
 
 // TODO test scenario when an error is logged - check that this is happening correctly
 
-describe("check company tests", () => {
+describe("confirm company tests", () => {
 
   it("should render the page with company data from the session", async () => {
 
@@ -98,14 +99,11 @@ describe("check company tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
     expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
-
     expect(mockSetObjectionSessionValue).toHaveBeenCalledWith(SESSION, SESSION_OBJECTION_ID, OBJECTION_ID);
-
     expect(mockCreateNewObjection).toHaveBeenCalledWith(dummyCompanyProfile.companyNumber, undefined);
-
     expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
-    expect(response.status).toEqual(200);
-    expect(response.text).toContain("Tell us why");
+    expect(response.status).toEqual(302);
+    expect(response.header.location).toEqual(OBJECTIONS_ENTER_INFORMATION);
   });
 });
 

--- a/test/controller/enter.information.controller.spec.unit.ts
+++ b/test/controller/enter.information.controller.spec.unit.ts
@@ -65,6 +65,10 @@ describe("enter information tests", () => {
   });
 
   it("should redirect to the document-upload page on post", async () => {
+
+    mockGetObjectionSessionValue.mockReset();
+    mockGetObjectionSessionValue.mockImplementationOnce(() => dummyCompanyProfile);
+
     const response = await request(app).post(OBJECTIONS_ENTER_INFORMATION)
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);

--- a/test/controller/enter.information.controller.spec.unit.ts
+++ b/test/controller/enter.information.controller.spec.unit.ts
@@ -9,15 +9,16 @@ import { Session } from "ch-node-session-handler/lib/session/model/Session";
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
 import app from "../../src/app";
-import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTION_ID } from "../../src/constants";
+import { OBJECTIONS_SESSION_NAME } from "../../src/constants";
 import authenticationMiddleware from "../../src/middleware/authentication.middleware";
 import objectionSessionMiddleware from "../../src/middleware/objection.session.middleware";
 import sessionMiddleware from "../../src/middleware/session.middleware";
 import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
 import { OBJECTIONS_DOCUMENT_UPLOAD, OBJECTIONS_ENTER_INFORMATION } from "../../src/model/page.urls";
-import { createNewObjection, updateObjectionReason } from "../../src/services/objection.service";
+import { updateObjectionReason } from "../../src/services/objection.service";
 import {
-  addToObjectionSession, retrieveCompanyProfileFromObjectionSession, retrieveFromObjectionSession,
+  retrieveCompanyProfileFromObjectionSession,
+  retrieveFromObjectionSession,
 } from "../../src/services/objection.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
 

--- a/test/controller/enter.information.controller.spec.unit.ts
+++ b/test/controller/enter.information.controller.spec.unit.ts
@@ -30,7 +30,6 @@ const SESSION: Session = {
 } as Session;
 
 const mockGetObjectionSessionValue = retrieveCompanyProfileFromObjectionSession as jest.Mock;
-const mockSetObjectionSessionValue = addToObjectionSession as jest.Mock;
 const mockRetrieveFromObjectionSession = retrieveFromObjectionSession as jest.Mock;
 
 const mockUpdateObjectionReason = updateObjectionReason as jest.Mock;
@@ -54,29 +53,12 @@ mockObjectionSessionMiddleware.mockImplementation((req: Request, res: Response, 
   return next(new Error("No session on request"));
 });
 
-const mockCreateNewObjection = createNewObjection as jest.Mock;
-
 describe("enter information tests", () => {
 
-  it("should call the API to create a new objection and then render the page", async () => {
-
-    mockGetObjectionSessionValue.mockReset();
-    mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
-
-    mockSetObjectionSessionValue.mockReset();
-
-    mockCreateNewObjection.mockReset();
-    mockCreateNewObjection.mockImplementation(() => OBJECTION_ID);
-
+  it("should render the page", async () => {
     const response = await request(app).get(OBJECTIONS_ENTER_INFORMATION)
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
-
-    expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
-
-    expect(mockSetObjectionSessionValue).toHaveBeenCalledWith(SESSION, SESSION_OBJECTION_ID, OBJECTION_ID);
-
-    expect(mockCreateNewObjection).toHaveBeenCalledWith(COMPANY_NUMBER, undefined);
 
     expect(response.status).toEqual(200);
     expect(response.text).toContain("Tell us why");

--- a/views/confirm-company.html
+++ b/views/confirm-company.html
@@ -78,14 +78,15 @@
         ]
       }) }}
 
-      {{ govukButton({
-        text: "Confirm and continue",
-        href: "/strike-off-objections/enter-information",
-        attributes: {
-          "data-event-id": "continue-button",
-          id: "submit"
-        }
-      }) }}
+      <form method="post">
+        {{ govukButton({
+          text: "Confirm and continue",
+          attributes: {
+            "data-event-id": "continue-button",
+            id: "submit"
+          }
+        }) }}
+      </form>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This is to prevent a new objection being created if the user goes back to the enter information page to change their reason.

Jira ticket at https://companieshouse.atlassian.net/browse/OBJ-106