### PR TITLE
obj-265 ensure values are kept on error page

### DIFF
--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -25,7 +25,7 @@ const validators = [
 export const post = [...validators, (req: Request, res: Response, next: NextFunction) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return showErrorsOnScreen(errors, res);
+    return showErrorsOnScreen(errors, req, res);
   }
   const fullNameValue: string = req.body.fullName;
   const shareIdentityValue: boolean = req.body.shareIdentity === "yes";
@@ -40,7 +40,7 @@ export const post = [...validators, (req: Request, res: Response, next: NextFunc
   }
 }];
 
-const showErrorsOnScreen = (errors: Result, res: Response) => {
+const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
   const errorListData: GovUkErrorData[] = [];
   let objectingEntityNameErr: GovUkErrorData | undefined = undefined;
   let shareIdentityErr: GovUkErrorData | undefined = undefined;
@@ -57,7 +57,12 @@ const showErrorsOnScreen = (errors: Result, res: Response) => {
       }
       errorListData.push(govUkErrorData);
     });
+
+  const fullNameValue: string = req.body.fullName
   return res.render(Templates.OBJECTING_ENTITY_NAME, {
+    fullNameValue,
+    isYesChecked: req.body.shareIdentity === "yes",
+    isNoChecked: req.body.shareIdentity === "no",
     shareIdentityErr,
     errorList: errorListData,
     objectingEntityNameErr,

--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -58,7 +58,7 @@ const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
       errorListData.push(govUkErrorData);
     });
 
-  const fullNameValue: string = req.body.fullName
+  const fullNameValue: string = req.body.fullName;
   return res.render(Templates.OBJECTING_ENTITY_NAME, {
     fullNameValue,
     isYesChecked: req.body.shareIdentity === "yes",

--- a/test/controller/objecting.entity.name.controller.spec.unit.ts
+++ b/test/controller/objecting.entity.name.controller.spec.unit.ts
@@ -89,6 +89,7 @@ describe("objecting entity name tests", () => {
     expect(response.text).toContain(ENTER_FULL_NAME);
     expect(response.text).not.toContain(SELECT_TO_DIVULGE);
     expect(response.text).toContain("value=\"yes\" checked");
+    expect(response.text).not.toContain("value=\"no\" checked");
   });
 
   it("should receive error message when no name is provided but a no divulge option is selected", async () => {
@@ -104,6 +105,7 @@ describe("objecting entity name tests", () => {
     expect(response.text).toContain(ENTER_FULL_NAME);
     expect(response.text).not.toContain(SELECT_TO_DIVULGE);
     expect(response.text).toContain("value=\"no\" checked");
+    expect(response.text).not.toContain("value=\"yes\" checked");
   });
 
   it("should receive error message when name is provided but no divulge option is selected", async () => {

--- a/test/controller/objecting.entity.name.controller.spec.unit.ts
+++ b/test/controller/objecting.entity.name.controller.spec.unit.ts
@@ -76,7 +76,7 @@ describe("objecting entity name tests", () => {
     expect(response.text).toContain(SELECT_TO_DIVULGE);
   });
 
-  it("should receive error message when no name is provided but a divulge option is selected", async () => {
+  it("should receive error message when no name is provided but a yes divulge option is selected", async () => {
     const response = await request(app)
       .post(OBJECTIONS_OBJECTING_ENTITY_NAME)
       .set("Referer", "/")
@@ -88,6 +88,22 @@ describe("objecting entity name tests", () => {
     expect(response.status).toEqual(200);
     expect(response.text).toContain(ENTER_FULL_NAME);
     expect(response.text).not.toContain(SELECT_TO_DIVULGE);
+    expect(response.text).toContain("value=\"yes\" checked");
+  });
+
+  it("should receive error message when no name is provided but a no divulge option is selected", async () => {
+    const response = await request(app)
+      .post(OBJECTIONS_OBJECTING_ENTITY_NAME)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        shareIdentity: "no"
+      });
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain(ENTER_FULL_NAME);
+    expect(response.text).not.toContain(SELECT_TO_DIVULGE);
+    expect(response.text).toContain("value=\"no\" checked");
   });
 
   it("should receive error message when name is provided but no divulge option is selected", async () => {
@@ -102,6 +118,7 @@ describe("objecting entity name tests", () => {
     expect(response.status).toEqual(200);
     expect(response.text).not.toContain(ENTER_FULL_NAME);
     expect(response.text).toContain(SELECT_TO_DIVULGE);
+    expect(response.text).toContain(FULL_NAME);
   });
 
   it("should render error page if session is not present", async () => {

--- a/views/objecting-entity-name.html
+++ b/views/objecting-entity-name.html
@@ -42,6 +42,7 @@
           },
           id: "fullName",
           name: "fullName",
+          value: fullNameValue,
           errorMessage: objectingEntityNameErr
         }) }}
 
@@ -60,11 +61,13 @@
           items: [
             {
               value: "yes",
-              text: "Yes"
+              text: "Yes",
+              checked: isYesChecked
             },
             {
               value: "no",
-              text: "No"
+              text: "No",
+              checked: isNoChecked
             }
           ]
         }) }}


### PR DESCRIPTION
Added values to name page, so that they are held when an error is displayed.