### PR TITLE
OBJ-292 Suppress addition of 'span' elements in list

### DIFF
--- a/views/check-your-answers.html
+++ b/views/check-your-answers.html
@@ -32,6 +32,8 @@
         Your details
       </h2>
 
+      {# Note that empty actions are added to the non-changeable rows below, to ensure that a `<span>` element isn't added to the list which will violate accessibility rules #}
+
       {{ govukSummaryList({
         rows: [
           {
@@ -40,6 +42,13 @@
             },
             value: {
               text: objection.created_by.email
+            },
+
+            actions: {
+              items: [
+                {
+                }
+              ]
             }
           },
           {
@@ -65,6 +74,13 @@
             },
             value: {
               text: shareIdentity
+            },
+
+            actions: {
+              items: [
+                {
+                }
+              ]
             }
           }
         ]


### PR DESCRIPTION
Previous to this change, 

   `<span class="govuk-summary-list__actions"></span>`
 
was getting added to the list. Now,


```
  <dd class="govuk-summary-list__actions">
    <a class="govuk-link" href="">
    </a>
  </dd>
```

is added, but shouldn't violate the accessibility rule since `<dd>` is allowed as a child element.
