### PR TITLE
OBJ-235 Add try-catch to async calls to api

### DIFF
--- a/src/controllers/enter.information.controller.ts
+++ b/src/controllers/enter.information.controller.ts
@@ -26,7 +26,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
   const reason: string = req.body.information;
 
-  await updateObjectionReason(company.companyNumber, objectionId, token, reason);
+  try {
+    await updateObjectionReason(company.companyNumber, objectionId, token, reason);
+  } catch (e) {
+    return next(e);
+  }
 
   return res.redirect(OBJECTIONS_DOCUMENT_UPLOAD);
 };

--- a/src/controllers/remove.document.controller.ts
+++ b/src/controllers/remove.document.controller.ts
@@ -37,7 +37,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const attachmentId: string = req.body[ATTACHMENT_ID_FIELD];
     if (attachmentId) {
       logger.debugRequest(req, `Removing document with attachmentId ${attachmentId}`);
-      await deleteAttachment(session, attachmentId);
+
+      try {
+        await deleteAttachment(session, attachmentId);
+      } catch (e) {
+        return next(e);
+      }
+
       return res.redirect(OBJECTIONS_DOCUMENT_UPLOAD);
     } else {
       return next(new Error("No attachment id found in form body"));

--- a/test/controller/enter.information.controller.spec.unit.ts
+++ b/test/controller/enter.information.controller.spec.unit.ts
@@ -98,6 +98,30 @@ describe("enter information tests", () => {
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_DOCUMENT_UPLOAD);
   });
+
+  it("should render error page if updating objection reason produces error", async () => {
+
+    mockGetObjectionSessionValue.mockReset();
+    mockGetObjectionSessionValue.mockImplementationOnce(() => dummyCompanyProfile);
+
+    mockRetrieveFromObjectionSession.mockReset();
+    mockRetrieveFromObjectionSession.mockImplementationOnce(() => OBJECTION_ID);
+
+    mockUpdateObjectionReason.mockReset();
+    mockUpdateObjectionReason.mockImplementationOnce(() => {
+      throw new Error("Test error");
+    });
+
+    const response = await request(app).post(OBJECTIONS_ENTER_INFORMATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({ information: REASON });
+
+    expect(mockUpdateObjectionReason).toHaveBeenCalledWith(COMPANY_NUMBER, OBJECTION_ID, undefined, REASON);
+
+    expect(response.status).toEqual(500);
+    expect(response.text).toContain("Sorry, there is a problem with the service");
+  });
 });
 
 const dummyCompanyProfile: ObjectionCompanyProfile = {

--- a/test/controller/remove.document.controller.spec.unit.ts
+++ b/test/controller/remove.document.controller.spec.unit.ts
@@ -94,6 +94,18 @@ describe("remove document url tests", () => {
     expect(res.text).toContain("Sorry, there is a problem with the service");
   });
 
+  it ("should return error page when api call throws error without rejecting promise", async () => {
+    mockGetAttachment.mockImplementationOnce(() => {
+      throw new Error("Test error");
+    });
+    const res = await request(app)
+      .get(OBJECTIONS_REMOVE_DOCUMENT + QUERY_ID)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+    expect(res.status).toEqual(500);
+    expect(res.text).toContain("Sorry, there is a problem with the service");
+  });
+
   it("should redirect to document upload page if No submitted", async () => {
     const res = await request(app)
       .post(OBJECTIONS_REMOVE_DOCUMENT)


### PR DESCRIPTION
Express 4 does not pass errors thrown in asynchronous calls to the global error handler.
This pr adds missing try/catch blocks to catch the errors and pass them to the error handler.