### PR TITLE
OBJ-292 Add visually hidden text to fix accessibility issue

### DIFF
--- a/views/check-your-answers.html
+++ b/views/check-your-answers.html
@@ -47,6 +47,7 @@
             actions: {
               items: [
                 {
+                  visuallyHiddenText: "email cannot be changed"
                 }
               ]
             }
@@ -79,6 +80,7 @@
             actions: {
               items: [
                 {
+                  visuallyHiddenText: "share identity cannot be changed"
                 }
               ]
             }


### PR DESCRIPTION
Last fix didn’t work (a different error only showed up in pipeline a11y test not ‘wave’ locally) but I've now tested this with ‘axe’ locally and I think it will do the trick. It generates (for e-mail):

```
  <dd class=“govuk-summary-list__actions”>
    <a class=“govuk-link” href=“”>
      <span class=“govuk-visually-hidden”> email cannot be changed</span>
    </a>
  </dd> 
```