### PR TITLE
OBJ-284 Updating unit tests for objecting.entity.name.controller

### DIFF
--- a/src/controllers/enter.information.controller.ts
+++ b/src/controllers/enter.information.controller.ts
@@ -11,7 +11,7 @@ import {
   retrieveFromObjectionSession,
 } from "../services/objection.session.service";
 
-export const get = async (req: Request, res: Response, next: NextFunction) => {
+export const get = (req: Request, res: Response) => {
   return res.render(Templates.ENTER_INFORMATION, {
     templateName: Templates.ENTER_INFORMATION,
   });

--- a/src/modules/sdk/objections/types.ts
+++ b/src/modules/sdk/objections/types.ts
@@ -57,11 +57,11 @@ export interface Attachment {
  * @interface
  */
 export interface Objection {
-  reason: string;
-  created_by: CreatedBy,
   attachments: Array<{
     name: string;
-  }>;
+  }>,
+  created_by: CreatedBy,
+  reason: string;
 }
 
 export interface CreatedBy {

--- a/test/modules/sdk/objections/service.spec.unit.ts
+++ b/test/modules/sdk/objections/service.spec.unit.ts
@@ -38,6 +38,10 @@ const dummyObjection: Objection = {
     {
       name: "document.pdf",
     }],
+  created_by: {
+    fullName: "bob",
+    shareIdentity: true,
+  },
   reason: "Owed some money",
 };
 


### PR DESCRIPTION
Fixing unit tests for objecting.entity.name.controller and added a couple more to test error page is shown if Objection name or sharedIdentity is missing.