### PR TITLE
OBJ-308 error bars around unerrored fields in objecting entity name page

### DIFF
--- a/views/objecting-entity-name.html
+++ b/views/objecting-entity-name.html
@@ -23,14 +23,6 @@
         }) }}
       {% endif %}
       <form method="post">
-        {% if errorList.length > 0 %}
-          {% set objectingEntityNameErr = {
-            text: objectingEntityNameErr.text
-          } %}
-        {% else %}
-          {% set objectingEntityNameErr = false %}
-        {% endif %}
-
         {{ govukInput({
           label: {
             text: "What is your full name?",


### PR DESCRIPTION
Ticket at https://companieshouse.atlassian.net/browse/OBJ-308

Removed an if block in objecting-entity-name.html that was causing an error outline to appear around the name field so long as any error was present.