### PR TITLE
OBJ-321 Add filing history call to service sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2501,13 +2501,13 @@
       }
     },
     "ch-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#5707a0ba5156a91cd9a5a46ef991afaf5cd3aaee",
-      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.10",
+      "version": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.30",
+      "from": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.30",
       "requires": {
-        "camelcase-keys": "^6.2.2",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.8",
-        "snakecase-keys": "^3.2.0"
+        "camelcase-keys": "~6.2.2",
+        "request": "~2.88.0",
+        "request-promise-native": "~1.0.8",
+        "snakecase-keys": "~3.2.0"
       },
       "dependencies": {
         "camelcase-keys": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "canvas": "^2.6.1",
     "ch-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#a3e0dcc57f91f63803e02ceef2cc5e4038de9a19",
     "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#3.0.1",
-    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.10",
+    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0.2.30",
     "cookie-parser": "~1.4.4",
     "express": "~4.16.1",
     "express-validator": "^6.6.1",

--- a/src/services/company.filing.history.service.ts
+++ b/src/services/company.filing.history.service.ts
@@ -2,6 +2,7 @@ import logger from "../utils/logger";
 import { createApiClient } from "ch-sdk-node";
 import Resource from "ch-sdk-node/dist/services/resource";
 import { CompanyFilingHistory } from "ch-sdk-node/dist/services/company-filing-history";
+import { inspect } from "util";
 
 export const getCompanyFilingHistory = async (companyNumber: string, category: string, token: string):
   Promise<CompanyFilingHistory> => {
@@ -18,7 +19,7 @@ export const getCompanyFilingHistory = async (companyNumber: string, category: s
     };
   }
 
-  logger.debug("Data from company filing history SDK call " + JSON.stringify(sdkResponse, null, 2));
+  logger.debug("Data from company filing history SDK call " + inspect(sdkResponse));
 
   return sdkResponse.resource as CompanyFilingHistory;
 }

--- a/src/services/company.filing.history.service.ts
+++ b/src/services/company.filing.history.service.ts
@@ -1,0 +1,24 @@
+import logger from "../utils/logger";
+import { createApiClient } from "ch-sdk-node";
+import Resource from "ch-sdk-node/dist/services/resource";
+import { CompanyFilingHistory } from "ch-sdk-node/dist/services/company-filing-history";
+
+export const getCompanyFilingHistory = async (companyNumber: string, category: string, token: string):
+  Promise<CompanyFilingHistory> => {
+  logger.debug("Creating CH SDK ApiClient");
+  const api = createApiClient(undefined, token);
+
+  logger.debug(`Looking for company filing history with company number ${companyNumber} and category ${category}`);
+  const sdkResponse: Resource<CompanyFilingHistory> =
+    await api.companyFilingHistory.getCompanyFilingHistory(companyNumber.toUpperCase(), category);
+
+  if (sdkResponse.httpStatusCode >= 400) {
+    throw {
+      status: sdkResponse.httpStatusCode,
+    };
+  }
+
+  logger.debug("Data from company filing history SDK call " + JSON.stringify(sdkResponse, null, 2));
+
+  return sdkResponse.resource as CompanyFilingHistory;
+}

--- a/test/services/company.filing.history.service.spec.ts
+++ b/test/services/company.filing.history.service.spec.ts
@@ -1,0 +1,54 @@
+import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
+import Resource from "ch-sdk-node/dist/services/resource";
+import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
+import { getCompanyProfile } from "../../src/services/company.profile.service";
+import CompanyFilingHistoryService from "ch-sdk-node/dist/services/company-filing-history/service";
+import { getCompanyFilingHistory } from "../../src/services/company.filing.history.service";
+import { CompanyFilingHistory, FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
+
+jest.mock("ch-sdk-node/dist/services/company-filing-history/service");
+
+const ACCESS_TOKEN = "KGGGUYUYJHHVK1234";
+
+describe("company filing history service unit tests", () => {
+  const mockGetCompanyFilingHistory = (CompanyFilingHistoryService.prototype.getCompanyFilingHistory as jest.Mock);
+
+  beforeEach(() => {
+    mockGetCompanyFilingHistory.mockReset();
+  });
+
+  it("converts company number to uppercase", async () => {
+    mockGetCompanyFilingHistory.mockResolvedValueOnce(dummySDKResponse);
+    const company = await getCompanyFilingHistory("sc100079", "category", ACCESS_TOKEN);
+    expect(mockGetCompanyFilingHistory).toBeCalledWith("SC100079");
+  });
+
+  it("returns a CompanyFilingHistory object", async () => {
+    mockGetCompanyFilingHistory.mockResolvedValueOnce(dummySDKResponse);
+    const companyFilingHistory = await getCompanyFilingHistory("12345678", "category", ACCESS_TOKEN);
+    expect(companyFilingHistory).toEqual(dummySDKResponse.resource);
+  });
+});
+
+const dummyFilingHistoryItem: FilingHistoryItem = {
+  category: "category",
+  date: "someDate",
+  description: "A description",
+  transactionId: "transactionId",
+  type: "a type"
+}
+
+const dummyCompanyFilingHistory: CompanyFilingHistory = {
+  etag: "etag",
+  items: [dummyFilingHistoryItem],
+  itemsPerPage: 0,
+  kind: "kind",
+  startIndex: 0,
+  totalCount: 0
+
+}
+
+const dummySDKResponse: Resource<CompanyFilingHistory> = {
+  httpStatusCode: 200,
+  resource: dummyCompanyFilingHistory,
+};

--- a/test/services/company.filing.history.service.spec.ts
+++ b/test/services/company.filing.history.service.spec.ts
@@ -23,6 +23,16 @@ describe("company filing history service unit tests", () => {
     expect(mockGetCompanyFilingHistory).toBeCalledWith("SC100079");
   });
 
+  it("returns a correct status code for error response", async () => {
+    mockGetCompanyFilingHistory.mockResolvedValueOnce(errorSdkResponse);
+    try {
+      await getCompanyFilingHistory("", "category", ACCESS_TOKEN);
+    } catch (e) {
+      expect(e.status).toEqual(404);
+    }
+    expect.assertions(1);
+  });
+
   it("returns a CompanyFilingHistory object", async () => {
     mockGetCompanyFilingHistory.mockResolvedValueOnce(dummySDKResponse);
     const companyFilingHistory = await getCompanyFilingHistory("12345678", "category", ACCESS_TOKEN);
@@ -51,4 +61,8 @@ const dummyCompanyFilingHistory: CompanyFilingHistory = {
 const dummySDKResponse: Resource<CompanyFilingHistory> = {
   httpStatusCode: 200,
   resource: dummyCompanyFilingHistory,
+};
+
+const errorSdkResponse: any = {
+  httpStatusCode: 404,
 };


### PR DESCRIPTION
This method in service sdk currently not called, but tested and works. Ready for use when we need to retrieve the date