### PR TITLE
Obj 321 extract gaz1 date from api response

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -5,7 +5,7 @@ import { SESSION_OBJECTION_ID } from "../constants";
 import { OBJECTIONS_ENTER_INFORMATION, OBJECTIONS_NO_STRIKE_OFF, OBJECTIONS_NOTICE_EXPIRED } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
 import { ApiError, ObjectionCreate, ObjectionStatus } from "../modules/sdk/objections";
-import { createNewObjection, getStatus } from "../services/objection.service";
+import { createNewObjection, getCompanyEligibility } from "../services/objection.service";
 import {
   addToObjectionSession,
   deleteObjectionCreateFromObjectionSession,
@@ -37,12 +37,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
       const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(req.session);
 
-      // TODO Display 'No notice in the Gazette' text if company action code is not eligible (OBJ-324 must be completed)
       const session: Session = req.session as Session;
       const token: string = retrieveAccessTokenFromSession(session);
 
       let latestGaz1Date: string;
-      if (getStatus(company.companyNumber, token)) {
+      if (getCompanyEligibility(company.companyNumber, token)) {
         latestGaz1Date = await getLatestGaz1Date(company.companyNumber, token);
       } else {
         latestGaz1Date = "No notice in The Gazette";

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -41,7 +41,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       const token: string = retrieveAccessTokenFromSession(session);
 
       let latestGaz1Date: string;
-      if (getCompanyEligibility(company.companyNumber, token)) {
+      if (await getCompanyEligibility(company.companyNumber, token)) {
         latestGaz1Date = await getLatestGaz1Date(company.companyNumber, token);
       } else {
         latestGaz1Date = "No notice in The Gazette";

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -15,11 +15,9 @@ import {
 } from "../services/objection.session.service";
 import logger from "../utils/logger";
 import { formatCHSDateForDisplay } from "../utils/date.formatter";
-import { getCompanyFilingHistory } from "../services/company.filing.history.service";
-import { CompanyFilingHistory, FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
+import { getLatestGaz1FilingHistoryItem } from "../services/company.filing.history.service";
+import { FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
 
-const GAZETTE_CATEGORY = "gazette";
-const GAZ1_TYPE = "GAZ1";
 const INELIGIBLE_PAGES = {
   [ObjectionStatus.INELIGIBLE_COMPANY_STRUCK_OFF]: OBJECTIONS_NOTICE_EXPIRED,
   [ObjectionStatus.INELIGIBLE_NO_DISSOLUTION_ACTION]: OBJECTIONS_NO_STRIKE_OFF,
@@ -89,18 +87,12 @@ const getIneligiblePage = (apiError: ApiError): string => {
 };
 
 const getLatestGaz1Date = async (companyNumber: string, token: string): Promise<string> => {
-  const companyGazetteHistory: CompanyFilingHistory = await getCompanyFilingHistory(companyNumber, GAZETTE_CATEGORY, token);
-  const companyGaz1History = companyGazetteHistory.items.filter(isGaz1);
-  // Response from API should be in reverse chronological order, so first in list is most recent
-  const mostRecentGaz1Item = companyGaz1History.shift();
+  const filingHistoryItem: FilingHistoryItem = await getLatestGaz1FilingHistoryItem(companyNumber, token);
 
-  if (!mostRecentGaz1Item) {
+  if (!filingHistoryItem) {
     throw new Error(`No GAZ1 present for company: ${companyNumber}`);
   }
 
-  return formatCHSDateForDisplay(mostRecentGaz1Item.date);
+  return formatCHSDateForDisplay(filingHistoryItem.date);
 };
 
-function isGaz1(element: FilingHistoryItem) {
-  return element.type === GAZ1_TYPE;
-}

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -5,7 +5,7 @@ import { SESSION_OBJECTION_ID } from "../constants";
 import { OBJECTIONS_ENTER_INFORMATION, OBJECTIONS_NO_STRIKE_OFF, OBJECTIONS_NOTICE_EXPIRED } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
 import { ApiError, ObjectionCreate, ObjectionStatus } from "../modules/sdk/objections";
-import { createNewObjection } from "../services/objection.service";
+import { createNewObjection, getStatus } from "../services/objection.service";
 import {
   addToObjectionSession,
   deleteObjectionCreateFromObjectionSession,
@@ -41,7 +41,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       const session: Session = req.session as Session;
       const token: string = retrieveAccessTokenFromSession(session);
 
-      const latestGaz1Date: string = await getLatestGaz1Date(company.companyNumber, token);
+      let latestGaz1Date: string;
+      if (getStatus(company.companyNumber, token)) {
+        latestGaz1Date = await getLatestGaz1Date(company.companyNumber, token);
+      } else {
+        latestGaz1Date = "No notice in The Gazette";
+      }
 
       return res.render(Templates.CONFIRM_COMPANY, {
         company,

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -33,11 +33,12 @@ const INELIGIBLE_PAGES = {
  */
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
-  if (req.session) {
-    try {
-      const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(req.session);
+  const session: Session = req.session as Session;
 
-      const session: Session = req.session as Session;
+  if (session) {
+    try {
+      const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
+
       const token: string = retrieveAccessTokenFromSession(session);
 
       let latestGaz1Date: string;

--- a/src/services/company.filing.history.service.ts
+++ b/src/services/company.filing.history.service.ts
@@ -37,6 +37,6 @@ const getCompanyFilingHistory = async (companyNumber: string, category: string, 
   return sdkResponse.resource as CompanyFilingHistory;
 };
 
-function isGaz1(element: FilingHistoryItem) {
+const isGaz1 = (element: FilingHistoryItem) => {
   return element.type === GAZ1_TYPE;
-}
+};

--- a/src/services/company.filing.history.service.ts
+++ b/src/services/company.filing.history.service.ts
@@ -1,17 +1,19 @@
 import logger from "../utils/logger";
 import { createApiClient } from "ch-sdk-node";
 import Resource from "ch-sdk-node/dist/services/resource";
-import { CompanyFilingHistory } from "ch-sdk-node/dist/services/company-filing-history";
+import { CompanyFilingHistory, FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
 import { inspect } from "util";
 
-export const getCompanyFilingHistory = async (companyNumber: string, category: string, token: string):
-  Promise<CompanyFilingHistory> => {
+const GAZETTE_CATEGORY = "gazette";
+const GAZ1_TYPE = "GAZ1";
+
+export const getLatestGaz1FilingHistoryItem = async (companyNumber: string, token: string): Promise<FilingHistoryItem> => {
   logger.debug("Creating CH SDK ApiClient");
   const api = createApiClient(undefined, token);
 
-  logger.debug(`Looking for company filing history with company number ${companyNumber} and category ${category}`);
+  logger.debug(`Looking for company filing history with company number ${companyNumber}`);
   const sdkResponse: Resource<CompanyFilingHistory> =
-      await api.companyFilingHistory.getCompanyFilingHistory(companyNumber.toUpperCase(), category);
+      await api.companyFilingHistory.getCompanyFilingHistory(companyNumber.toUpperCase(), GAZETTE_CATEGORY);
 
   if (sdkResponse.httpStatusCode >= 400) {
     throw {
@@ -21,5 +23,15 @@ export const getCompanyFilingHistory = async (companyNumber: string, category: s
 
   logger.debug("Data from company filing history SDK call " + inspect(sdkResponse));
 
-  return sdkResponse.resource as CompanyFilingHistory;
+  const companyGazetteHistory: CompanyFilingHistory = sdkResponse.resource as CompanyFilingHistory;
+
+  const companyGaz1History = companyGazetteHistory.items.filter(isGaz1);
+  // Response from API should be in reverse chronological order, so first in list is most recent
+  const mostRecentGaz1Item = companyGaz1History.shift();
+
+  return mostRecentGaz1Item as FilingHistoryItem;
 };
+
+function isGaz1(element: FilingHistoryItem) {
+  return element.type === GAZ1_TYPE;
+}

--- a/src/services/company.filing.history.service.ts
+++ b/src/services/company.filing.history.service.ts
@@ -11,7 +11,7 @@ export const getCompanyFilingHistory = async (companyNumber: string, category: s
 
   logger.debug(`Looking for company filing history with company number ${companyNumber} and category ${category}`);
   const sdkResponse: Resource<CompanyFilingHistory> =
-    await api.companyFilingHistory.getCompanyFilingHistory(companyNumber.toUpperCase(), category);
+      await api.companyFilingHistory.getCompanyFilingHistory(companyNumber.toUpperCase(), category);
 
   if (sdkResponse.httpStatusCode >= 400) {
     throw {
@@ -22,4 +22,4 @@ export const getCompanyFilingHistory = async (companyNumber: string, category: s
   logger.debug("Data from company filing history SDK call " + inspect(sdkResponse));
 
   return sdkResponse.resource as CompanyFilingHistory;
-}
+};

--- a/src/utils/date.formatter.ts
+++ b/src/utils/date.formatter.ts
@@ -4,5 +4,5 @@ const DISPLAY_DATE_FORMAT = "D MMMM YYYY";
 const CHS_DATE_FORMAT = "YYYY-MM-DD";
 
 export const formatCHSDateForDisplay = (inputDate: string): string => {
-  return moment(inputDate, CHS_DATE_FORMAT, true).format( DISPLAY_DATE_FORMAT);
+  return moment(inputDate, CHS_DATE_FORMAT, true).format(DISPLAY_DATE_FORMAT);
 };

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -22,7 +22,7 @@ import {
   OBJECTIONS_NOTICE_EXPIRED
 } from "../../src/model/page.urls";
 import { ApiError, ObjectionCreate } from "../../src/modules/sdk/objections";
-import { createNewObjection } from "../../src/services/objection.service";
+import { createNewObjection, getStatus } from "../../src/services/objection.service";
 import {
   addToObjectionSession,
   retrieveAccessTokenFromSession,
@@ -66,6 +66,7 @@ mockObjectionSessionMiddleware.mockImplementation((req: Request, res: Response, 
 });
 
 const mockCreateNewObjection = createNewObjection as jest.Mock;
+const mockGetStatus = getStatus as jest.Mock;
 
 // TODO test scenario when an error is logged - check that this is happening correctly
 
@@ -77,32 +78,33 @@ describe("confirm company tests", () => {
     mockCompanyFilingHistory.mockReset();
   });
 
-  // TODO Add fixture to suppress call to get filing history and re-include later
+  it("should render the page with company data from the session", async () => {
 
-  // it("should render the page with company data from the session", async () => {
+    mockGetObjectionSessionValue.mockReset();
+    mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
-  //   mockGetObjectionSessionValue.mockReset();
-  //   mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
+    mockGetStatus.mockReset();
+    mockGetStatus.mockImplementation(() => false);
 
-  //   const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
-  //     .set("Referer", "/")
-  //     .set("Cookie", [`${COOKIE_NAME}=123`]);
+    const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-  //   expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
-  //   expect(response.status).toEqual(200);
+    expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
+    expect(response.status).toEqual(200);
 
-  //   // TODO "girl's" caused the html version of apostrophe to be returned
-  //   // something like eg &1233; - just check that apostrophe is rendered ok in browser
-  //   expect(response.text).toContain("Girls school trust");
-  //   expect(response.text).toContain("00006400");
-  //   expect(response.text).toContain("Active");
-  //   expect(response.text).toContain("26 June 1872");
-  //   expect(response.text).toContain("limited");
-  //   expect(response.text).toContain("line1");
-  //   expect(response.text).toContain("line2");
-  //   expect(response.text).toContain("post code");
-  //   expect(response.text).toContain("No notice in The Gazette");
-  // });
+    // TODO "girl's" caused the html version of apostrophe to be returned
+    // something like eg &1233; - just check that apostrophe is rendered ok in browser
+    expect(response.text).toContain("Girls school trust");
+    expect(response.text).toContain("00006400");
+    expect(response.text).toContain("Active");
+    expect(response.text).toContain("26 June 1872");
+    expect(response.text).toContain("limited");
+    expect(response.text).toContain("line1");
+    expect(response.text).toContain("line2");
+    expect(response.text).toContain("post code");
+    expect(response.text).toContain("No notice in The Gazette");
+  });
 
   it("should call the API to create a new objection then render the enter information page", async () => {
 
@@ -237,6 +239,9 @@ describe("confirm company tests", () => {
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
+    mockGetStatus.mockReset();
+    mockGetStatus.mockImplementation(() => true);
+
     mockCompanyFilingHistory.mockResolvedValueOnce(dummyCompanyFilingHistoryWithNoGaz1Date);
 
     const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
@@ -262,6 +267,9 @@ describe("confirm company tests", () => {
 
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
+
+    mockGetStatus.mockReset();
+    mockGetStatus.mockImplementation(() => true);
 
     mockCompanyFilingHistory.mockResolvedValueOnce(dummyCompanyFilingHistory);
 

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -22,7 +22,7 @@ import {
   OBJECTIONS_NOTICE_EXPIRED
 } from "../../src/model/page.urls";
 import { ApiError, ObjectionCreate } from "../../src/modules/sdk/objections";
-import { createNewObjection, getStatus } from "../../src/services/objection.service";
+import { createNewObjection, getCompanyEligibility } from "../../src/services/objection.service";
 import {
   addToObjectionSession,
   retrieveAccessTokenFromSession,
@@ -66,7 +66,7 @@ mockObjectionSessionMiddleware.mockImplementation((req: Request, res: Response, 
 });
 
 const mockCreateNewObjection = createNewObjection as jest.Mock;
-const mockGetStatus = getStatus as jest.Mock;
+const mockGetCompanyEligibility = getCompanyEligibility as jest.Mock;
 
 // TODO test scenario when an error is logged - check that this is happening correctly
 
@@ -83,8 +83,8 @@ describe("confirm company tests", () => {
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
-    mockGetStatus.mockReset();
-    mockGetStatus.mockImplementation(() => false);
+    mockGetCompanyEligibility.mockReset();
+    mockGetCompanyEligibility.mockImplementation(() => false);
 
     const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
       .set("Referer", "/")
@@ -239,8 +239,8 @@ describe("confirm company tests", () => {
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
-    mockGetStatus.mockReset();
-    mockGetStatus.mockImplementation(() => true);
+    mockGetCompanyEligibility.mockReset();
+    mockGetCompanyEligibility.mockImplementation(() => true);
 
     mockCompanyFilingHistory.mockResolvedValueOnce(dummyCompanyFilingHistoryWithNoGaz1Date);
 
@@ -268,8 +268,8 @@ describe("confirm company tests", () => {
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
-    mockGetStatus.mockReset();
-    mockGetStatus.mockImplementation(() => true);
+    mockGetCompanyEligibility.mockReset();
+    mockGetCompanyEligibility.mockImplementation(() => true);
 
     mockCompanyFilingHistory.mockResolvedValueOnce(dummyCompanyFilingHistory);
 

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -31,8 +31,8 @@ import {
   deleteObjectionCreateFromObjectionSession
 } from "../../src/services/objection.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
-import { getCompanyFilingHistory } from "../../src/services/company.filing.history.service";
-import { CompanyFilingHistory } from "ch-sdk-node/dist/services/company-filing-history";
+import { getLatestGaz1FilingHistoryItem } from "../../src/services/company.filing.history.service";
+import { FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
 
 const OBJECTION_ID = "123456";
 const ACCESS_TOKEN = "KGGGUYUYJHHVK1234";
@@ -72,10 +72,10 @@ const mockGetCompanyEligibility = getCompanyEligibility as jest.Mock;
 
 describe("confirm company tests", () => {
 
-  const mockCompanyFilingHistory = getCompanyFilingHistory as jest.Mock;
+  const mockLatestGaz1FilingHistoryItem = getLatestGaz1FilingHistoryItem as jest.Mock;
 
   beforeEach(() => {
-    mockCompanyFilingHistory.mockReset();
+    mockLatestGaz1FilingHistoryItem.mockReset();
   });
 
   it("should render the page with company data from the session", async () => {
@@ -242,7 +242,7 @@ describe("confirm company tests", () => {
     mockGetCompanyEligibility.mockReset();
     mockGetCompanyEligibility.mockImplementation(() => true);
 
-    mockCompanyFilingHistory.mockResolvedValueOnce(dummyCompanyFilingHistoryWithNoGaz1Date);
+    mockLatestGaz1FilingHistoryItem.mockResolvedValueOnce(undefined);
 
     const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
       .set("Referer", "/")
@@ -255,7 +255,7 @@ describe("confirm company tests", () => {
 
   });
 
-  it("should correctly extract the latest GAZ1 date from the filing history if action code is eligible", async () => {
+  it("should correctly display the latest GAZ1 date from the filing history if action code is eligible", async () => {
 
     const mockValidAccessToken = retrieveAccessTokenFromSession as jest.Mock;
 
@@ -271,7 +271,7 @@ describe("confirm company tests", () => {
     mockGetCompanyEligibility.mockReset();
     mockGetCompanyEligibility.mockImplementation(() => true);
 
-    mockCompanyFilingHistory.mockResolvedValueOnce(dummyCompanyFilingHistory);
+    mockLatestGaz1FilingHistoryItem.mockResolvedValueOnce(dummyFilingHistoryItem);
 
     const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
       .set("Referer", "/")
@@ -298,57 +298,12 @@ const dummyCompanyProfile: ObjectionCompanyProfile = {
   incorporationDate: "26 June 1872",
 };
 
-const dummyCompanyFilingHistory: CompanyFilingHistory = {
-  etag: "",
-  filingHistoryStatus: "",
-  items: [
-    {
-      // This entry should be ignored when extracting the GAZ1 date as type is different
-      category: "",
-      date: "2015-04-14",
-      description: "",
-      transactionId: "",
-      type: "288a",
-    },
-    {
-      category: "",
-      date: "2015-04-14",
-      description: "",
-      transactionId: "",
-      type: "GAZ1",
-    },
-    // And this entry shouldn't be used as it's last in the list
-    {
-      category: "",
-      date: "2011-07-21",
-      description: "",
-      transactionId: "",
-      type: "GAZ1",
-    },
-  ],
-  itemsPerPage: 1,
-  kind: "",
-  startIndex: 1,
-  totalCount: 1,
-};
-
-const dummyCompanyFilingHistoryWithNoGaz1Date: CompanyFilingHistory = {
-  etag: "",
-  filingHistoryStatus: "",
-  items: [
-    {
-      // This entry should be ignored when extracting the GAZ1 date as type is different
-      category: "",
-      date: "2015-04-14",
-      description: "",
-      transactionId: "",
-      type: "288a",
-    },
-  ],
-  itemsPerPage: 1,
-  kind: "",
-  startIndex: 1,
-  totalCount: 1,
+const dummyFilingHistoryItem: FilingHistoryItem = {
+  category: "",
+  date: "2015-04-14",
+  description: "",
+  transactionId: "",
+  type: "GAZ1",
 };
 
 const dummyObjectionCreate: ObjectionCreate = {

--- a/test/modules/sdk/objections/service.spec.unit.ts
+++ b/test/modules/sdk/objections/service.spec.unit.ts
@@ -64,7 +64,7 @@ describe("objections SDK service unit tests", () => {
       },
     });
     const returnedEligibility: boolean = await objectionsSdk.getCompanyEligibility(COMPANY_NUMBER,
-                                                                            ACCESS_TOKEN);
+                                                                                   ACCESS_TOKEN);
 
     expect(returnedEligibility).toEqual(true);
     expect(mockMakeAPICall).toBeCalled();

--- a/test/services/company.filing.history.service.spec.unit.ts
+++ b/test/services/company.filing.history.service.spec.unit.ts
@@ -1,7 +1,4 @@
-// import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
 import Resource from "ch-sdk-node/dist/services/resource";
-// import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
-// import { getCompanyProfile } from "../../src/services/company.profile.service";
 import CompanyFilingHistoryService from "ch-sdk-node/dist/services/company-filing-history/service";
 import { getCompanyFilingHistory } from "../../src/services/company.filing.history.service";
 import { CompanyFilingHistory, FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";

--- a/test/services/company.filing.history.service.spec.unit.ts
+++ b/test/services/company.filing.history.service.spec.unit.ts
@@ -1,7 +1,7 @@
-import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
+// import { CompanyProfile } from "ch-sdk-node/dist/services/company-profile";
 import Resource from "ch-sdk-node/dist/services/resource";
-import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
-import { getCompanyProfile } from "../../src/services/company.profile.service";
+// import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
+// import { getCompanyProfile } from "../../src/services/company.profile.service";
 import CompanyFilingHistoryService from "ch-sdk-node/dist/services/company-filing-history/service";
 import { getCompanyFilingHistory } from "../../src/services/company.filing.history.service";
 import { CompanyFilingHistory, FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
@@ -19,8 +19,8 @@ describe("company filing history service unit tests", () => {
 
   it("converts company number to uppercase", async () => {
     mockGetCompanyFilingHistory.mockResolvedValueOnce(dummySDKResponse);
-    const company = await getCompanyFilingHistory("sc100079", "category", ACCESS_TOKEN);
-    expect(mockGetCompanyFilingHistory).toBeCalledWith("SC100079");
+    await getCompanyFilingHistory("sc100079", "category", ACCESS_TOKEN);
+    expect(mockGetCompanyFilingHistory).toBeCalledWith("SC100079", "category");
   });
 
   it("returns a correct status code for error response", async () => {
@@ -46,7 +46,7 @@ const dummyFilingHistoryItem: FilingHistoryItem = {
   description: "A description",
   transactionId: "transactionId",
   type: "a type"
-}
+};
 
 const dummyCompanyFilingHistory: CompanyFilingHistory = {
   etag: "etag",
@@ -55,8 +55,7 @@ const dummyCompanyFilingHistory: CompanyFilingHistory = {
   kind: "kind",
   startIndex: 0,
   totalCount: 0
-
-}
+};
 
 const dummySDKResponse: Resource<CompanyFilingHistory> = {
   httpStatusCode: 200,

--- a/views/confirm-company.html
+++ b/views/confirm-company.html
@@ -37,6 +37,7 @@
         rows: [
           {
             key: {
+              classes: "govuk-!-width-full",
               text: "Company number"
             },
             value: {

--- a/views/confirm-company.html
+++ b/views/confirm-company.html
@@ -74,6 +74,14 @@
             value: {
               html: address
             }
+          },
+          {
+            key: {
+              text: "Date notice published in The Gazette"
+            },
+            value: {
+              text: latestGaz1Date
+            }
           }
         ]
       }) }}


### PR DESCRIPTION
Checks if GAZ1 date should be displayed and if yes makes a call to get it, extract it from the response and display. If not, static text is displayed on the 'confirm' screen.