### PR TITLE
OBJ-353 Reverting change to show error screen if submitting more than…

### DIFF
--- a/src/controllers/check.your.answers.controller.ts
+++ b/src/controllers/check.your.answers.controller.ts
@@ -39,12 +39,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
   return next(new Error("No Session present"));
 };
 
-export const post = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    await submitObjection(req.session as Session);
-    return res.redirect(OBJECTIONS_CONFIRMATION);
-  } catch (e) {
-    logger.errorRequest(req, "Error confirming and submitting objection");
-    return next(e);
-  }
+export const post = async (req: Request, res: Response) => {
+  await submitObjection(req.session as Session);
+
+  return res.redirect(OBJECTIONS_CONFIRMATION);
 };

--- a/test/controller/check.your.answers.controller.spec.unit.ts
+++ b/test/controller/check.your.answers.controller.spec.unit.ts
@@ -117,21 +117,6 @@ describe("check company tests", () => {
     expect(res.status).toEqual(302);
     expect(res.header.location).toEqual(OBJECTIONS_CONFIRMATION);
   });
-
-  it ("should show the error screen if api returns error on post", async () => {
-
-    mockSubmitObjection.mockRejectedValueOnce(new Error("Invalid status"));
-
-    const res = await request(app)
-      .post(OBJECTIONS_CHECK_YOUR_ANSWERS)
-      .set("referer", "/")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
-
-    expect(mockSubmitObjection).toBeCalledWith(dummySession);
-
-    expect(res.status).toEqual(500);
-    expect(res.text).toContain("Sorry, there is a problem with the service");
-  });
 });
 
 const dummyCompanyProfile: ObjectionCompanyProfile = {


### PR DESCRIPTION
… once

Reverting the change to catch exception when submitting the objection to allow for users who double click. Without the fix, the first request would return before the second times out. With the fix, the second request returns showing the error screen which maybe confusing to users who double click.