### PR TITLE
Bug/obj 342 confirm company fails on second attempt

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -8,7 +8,6 @@ import { ApiError, ObjectionCreate, ObjectionStatus } from "../modules/sdk/objec
 import { createNewObjection, getCompanyEligibility } from "../services/objection.service";
 import {
   addToObjectionSession,
-  deleteObjectionCreateFromObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
   retrieveObjectionCreateFromObjectionSession
@@ -61,17 +60,15 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 };
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
-  const session: Session = req.session as Session;
   try {
+    const session: Session = req.session as Session;
     const token: string = retrieveAccessTokenFromSession(session);
     const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
     const objectionCreate: ObjectionCreate = retrieveObjectionCreateFromObjectionSession(session);
     const objectionId = await createNewObjection(company.companyNumber, token, objectionCreate);
     addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
-    deleteObjectionCreateFromObjectionSession(session);
     return res.redirect(OBJECTIONS_ENTER_INFORMATION);
   } catch (e) {
-    deleteObjectionCreateFromObjectionSession(session);
     if (e.status === 400 && e.data.status) {
       const ineligiblePage = getIneligiblePage(e);
       if (ineligiblePage) {

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -8,6 +8,7 @@ import { ApiError, ObjectionCreate, ObjectionStatus } from "../modules/sdk/objec
 import { createNewObjection, getCompanyEligibility } from "../services/objection.service";
 import {
   addToObjectionSession,
+  deleteObjectionCreateFromObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
   retrieveObjectionCreateFromObjectionSession
@@ -60,8 +61,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 };
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
+  const session: Session = req.session as Session;
   try {
-    const session: Session = req.session as Session;
     const token: string = retrieveAccessTokenFromSession(session);
     const company: ObjectionCompanyProfile = retrieveCompanyProfileFromObjectionSession(session);
     const objectionCreate: ObjectionCreate = retrieveObjectionCreateFromObjectionSession(session);
@@ -69,6 +70,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
     return res.redirect(OBJECTIONS_ENTER_INFORMATION);
   } catch (e) {
+    deleteObjectionCreateFromObjectionSession(session);
     if (e.status === 400 && e.data.status) {
       const ineligiblePage = getIneligiblePage(e);
       if (ineligiblePage) {

--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -2,7 +2,12 @@ import { Session } from "ch-node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import { SESSION_OBJECTION_ID } from "../constants";
 import { Templates } from "../model/template.paths";
-import { deleteFromObjectionSession, retrieveFromObjectionSession, retrieveUserEmailFromSession } from "../services/objection.session.service";
+import {
+  deleteFromObjectionSession,
+  deleteObjectionCreateFromObjectionSession,
+  retrieveFromObjectionSession,
+  retrieveUserEmailFromSession
+} from "../services/objection.session.service";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   const session: Session | undefined  = req.session;
@@ -12,6 +17,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
     // Objection has been submitted and should no longer be referenced by this web session, so remove the objection id from the session
     deleteFromObjectionSession(session, SESSION_OBJECTION_ID);
+    deleteObjectionCreateFromObjectionSession(session);
 
     return res.render(Templates.CONFIRMATION, {
       email,

--- a/src/services/objection.session.service.ts
+++ b/src/services/objection.session.service.ts
@@ -80,7 +80,6 @@ export const deleteObjectionCreateFromObjectionSession = (session: Session): voi
     delete objectionsExtraData[SESSION_OBJECTION_CREATE];
     return;
   }
-  throw new Error("Error deleting objection create");
 };
 
 export const addCompanyProfileToObjectionSession = (session: Session, company: ObjectionCompanyProfile): void => {

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -27,8 +27,7 @@ import {
   addToObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
-  retrieveObjectionCreateFromObjectionSession,
-  deleteObjectionCreateFromObjectionSession
+  retrieveObjectionCreateFromObjectionSession
 } from "../../src/services/objection.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
 import { getLatestGaz1FilingHistoryItem } from "../../src/services/company.filing.history.service";
@@ -42,7 +41,6 @@ const SESSION: Session = {
 
 const mockGetObjectionSessionValue = retrieveCompanyProfileFromObjectionSession as jest.Mock;
 const mockGetObjectCreate = retrieveObjectionCreateFromObjectionSession as jest.Mock;
-const mockDeleteObjectCreate = deleteObjectionCreateFromObjectionSession as jest.Mock;
 
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
@@ -119,14 +117,11 @@ describe("confirm company tests", () => {
     mockGetObjectCreate.mockReset();
     mockGetObjectCreate.mockImplementation(() =>  dummyObjectionCreate );
 
-    mockDeleteObjectCreate.mockReset();
-
     const response = await request(app).post(OBJECTIONS_CONFIRM_COMPANY)
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
     expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(mockSetObjectionSessionValue).toHaveBeenCalledWith(SESSION, SESSION_OBJECTION_ID, OBJECTION_ID);
     expect(mockCreateNewObjection).toHaveBeenCalledWith(dummyCompanyProfile.companyNumber, undefined, dummyObjectionCreate);
     expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
@@ -144,7 +139,6 @@ describe("confirm company tests", () => {
       status: 400,
     };
 
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -159,7 +153,6 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NOTICE_EXPIRED);
   });
@@ -174,7 +167,6 @@ describe("confirm company tests", () => {
       status: 400,
     };
 
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -189,7 +181,6 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NO_STRIKE_OFF);
   });
@@ -206,7 +197,6 @@ describe("confirm company tests", () => {
 
     const ERROR_500 = "Sorry, there is a problem with the service";
 
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -221,7 +211,6 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(500);
     expect(response.text).toContain(ERROR_500);
   });

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -25,10 +25,10 @@ import { ApiError, ObjectionCreate } from "../../src/modules/sdk/objections";
 import { createNewObjection, getCompanyEligibility } from "../../src/services/objection.service";
 import {
   addToObjectionSession,
+  deleteObjectionCreateFromObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
-  retrieveObjectionCreateFromObjectionSession
-} from "../../src/services/objection.session.service";
+  retrieveObjectionCreateFromObjectionSession } from "../../src/services/objection.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
 import { getLatestGaz1FilingHistoryItem } from "../../src/services/company.filing.history.service";
 import { FilingHistoryItem } from "ch-sdk-node/dist/services/company-filing-history";
@@ -41,6 +41,7 @@ const SESSION: Session = {
 
 const mockGetObjectionSessionValue = retrieveCompanyProfileFromObjectionSession as jest.Mock;
 const mockGetObjectCreate = retrieveObjectionCreateFromObjectionSession as jest.Mock;
+const mockDeleteObjectCreate = deleteObjectionCreateFromObjectionSession as jest.Mock;
 
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
@@ -139,6 +140,7 @@ describe("confirm company tests", () => {
       status: 400,
     };
 
+    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -153,6 +155,7 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
+    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NOTICE_EXPIRED);
   });
@@ -167,6 +170,7 @@ describe("confirm company tests", () => {
       status: 400,
     };
 
+    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -181,6 +185,7 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
+    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NO_STRIKE_OFF);
   });
@@ -197,6 +202,7 @@ describe("confirm company tests", () => {
 
     const ERROR_500 = "Sorry, there is a problem with the service";
 
+    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -211,6 +217,7 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
+    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(500);
     expect(response.text).toContain(ERROR_500);
   });


### PR DESCRIPTION
… user to go back and change company

The ObjectionCreate (objecting entity details) got deleted after confirming the company. When a user went back and changed company, the app would crash as the ObjectionCreate is needed but had been deleted. I've moved the deletion of this to the end of the journey when the user submits.