### PR TITLE
Adding docker files but also removed 'canvas' from dependencies to he…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!api-enumerations
+!src
+!views
+!package-lock.json
+!package.json
+!tsconfig.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/node:14-alpine-builder
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/node:14-alpine-runtime
+COPY api-enumerations ./api-enumerations
+RUN cp -r ./dist/* ./ && rm -rf ./dist
+
+CMD ["/app/bin/www.js", "--", "3000"]
+
+EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "axios": "^0.19.2",
     "bufferutil": "^4.0.1",
     "busboy": "^0.3.1",
-    "canvas": "^2.6.1",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/node-session-handler": "^4.1.5",
     "cookie-parser": "~1.4.4",


### PR DESCRIPTION
…lp docker deployment

WARNING: To get this running on Docker we removed the 'canvas' dependency. The app hasn't been fully tested without this so we need to end-to-end test it to make sure it still runs ok without it before merging.