### PR TITLE
Adding missing links field to company profile test

### DIFF
--- a/test/services/company.profile.service.spec.unit.ts
+++ b/test/services/company.profile.service.spec.unit.ts
@@ -63,6 +63,7 @@ const dummySDKResponse: Resource<CompanyProfile> = {
     hasCharges: false,
     hasInsolvencyHistory: false,
     jurisdiction: "england-wales",
+    links: {},
     registeredOfficeAddress: {
       addressLineOne: "line1",
       addressLineTwo: "line2",


### PR DESCRIPTION
company.profile.spec.unit.ts was showing a warning that field 'links' was missing from the company profile object so this is to add it.