### PR TITLE
Removing piwik scripts from download page so it wont be tracked

### DIFF
--- a/src/controllers/check.your.answers.controller.ts
+++ b/src/controllers/check.your.answers.controller.ts
@@ -29,7 +29,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         companyNumber,
         objection,
         shareIdentity,
-        templateName: Templates.CHECK_YOUR_ANSWERS,
       });
     } catch (e) {
       logger.errorRequest(req, "Error retrieving company profile from session");

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -106,7 +106,6 @@ const buildError = (res: Response, errorMessage: string): void => {
   return res.render(Templates.COMPANY_NUMBER, {
     companyNumberErr: companyNumberErrorData,
     errorList: [companyNumberErrorData],
-    templateName: Templates.COMPANY_NUMBER,
   });
 };
 

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -49,7 +49,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       return res.render(Templates.CONFIRM_COMPANY, {
         company,
         latestGaz1Date,
-        templateName: Templates.CONFIRM_COMPANY,
       });
     } catch (e) {
       logger.errorRequest(req, "Error retrieving company profile from session");

--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -22,7 +22,6 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     return res.render(Templates.CONFIRMATION, {
       email,
       objectionId,
-      templateName: Templates.CONFIRMATION,
     });
   } else {
     return next(new Error("No Session present"));

--- a/src/controllers/document_upload/document.upload.controller.ts
+++ b/src/controllers/document_upload/document.upload.controller.ts
@@ -37,7 +37,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
   return res.render(Templates.DOCUMENT_UPLOAD,
                     {
                       attachments,
-                      templateName: Templates.DOCUMENT_UPLOAD,
                     });
 };
 

--- a/src/controllers/document_upload/html.upload.responder.strategy.ts
+++ b/src/controllers/document_upload/html.upload.responder.strategy.ts
@@ -44,7 +44,6 @@ export class HtmlUploadResponderStrategy implements UploadResponderStrategy {
       attachments,
       documentUploadErr: errorData,
       errorList: [errorData],
-      templateName: Templates.DOCUMENT_UPLOAD,
     });
     return Promise.resolve();
   };

--- a/src/controllers/enter.information.controller.ts
+++ b/src/controllers/enter.information.controller.ts
@@ -49,7 +49,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 const renderPageWithSessionDataIfPresent = async (req: Request, res: Response) => {
   const objection: Objection = await getObjectionFromSession(req);
   let existingInformation;
-  if (objection && objection.reason) {
+  if (objection.reason) {
     existingInformation = objection.reason;
   }
   if (existingInformation) {

--- a/src/controllers/enter.information.controller.ts
+++ b/src/controllers/enter.information.controller.ts
@@ -55,12 +55,9 @@ const renderPageWithSessionDataIfPresent = async (req: Request, res: Response) =
   if (existingInformation) {
     return res.render(Templates.ENTER_INFORMATION, {
       information: existingInformation,
-      templateName: Templates.ENTER_INFORMATION,
     });
   } else {
-    return res.render(Templates.ENTER_INFORMATION, {
-      templateName: Templates.ENTER_INFORMATION,
-    });
+    return res.render(Templates.ENTER_INFORMATION);
   }
 };
 

--- a/src/controllers/index.controller.ts
+++ b/src/controllers/index.controller.ts
@@ -6,9 +6,7 @@ import { Templates } from "../model/template.paths";
 import logger from "../utils/logger";
 
 export const get = (req: Request, res: Response) => {
-  return res.render(Templates.INDEX, {
-    templateName: Templates.INDEX,
-  });
+  return res.render(Templates.INDEX);
 };
 
 export const post = (req: Request, res: Response) => {

--- a/src/controllers/no.strike.off.controller.ts
+++ b/src/controllers/no.strike.off.controller.ts
@@ -12,6 +12,5 @@ export const get = (req: Request, res: Response) => {
 
   return res.render(Templates.NO_STRIKE_OFF, {
     companyName,
-    templateName: Templates.NO_STRIKE_OFF,
   });
 };

--- a/src/controllers/notice.expired.controller.ts
+++ b/src/controllers/notice.expired.controller.ts
@@ -12,6 +12,5 @@ export const get = (req: Request, res: Response) => {
 
   return res.render(Templates.NOTICE_EXPIRED, {
     companyName,
-    templateName: Templates.NOTICE_EXPIRED,
   });
 };

--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -41,7 +41,6 @@ const showPageWithSessionDataIfPresent = (session: Session, res: Response) => {
     fullNameValue: existingName,
     isYesChecked: yesChecked,
     isNoChecked: noChecked,
-    templateName: Templates.OBJECTING_ENTITY_NAME,
   });
 };
 
@@ -55,7 +54,6 @@ const showPageWithMongoData = async (session: Session, res: Response, next: Next
         fullNameValue: existingName,
         isYesChecked: existingShareIdentity,
         isNoChecked: !existingShareIdentity,
-        templateName: Templates.OBJECTING_ENTITY_NAME,
       });
     } else {
       return next(new Error("Existing data not present"));
@@ -156,6 +154,5 @@ const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
     shareIdentityErr,
     errorList: errorListData,
     objectingEntityNameErr,
-    templateName: Templates.OBJECTING_ENTITY_NAME,
   });
 };

--- a/src/controllers/remove.document.controller.ts
+++ b/src/controllers/remove.document.controller.ts
@@ -29,7 +29,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     return res.render(Templates.REMOVE_DOCUMENT, {
       attachmentId,
       fileName: attachment.name,
-      templateName: Templates.REMOVE_DOCUMENT,
     });
   } catch (e) {
     logger.errorRequest(req, e.message);
@@ -78,6 +77,5 @@ const showErrorsOnScreen = async (errors: Result, req: Request, res: Response) =
     errorList: [removeDocumentError],
     fileName: attachment.name,
     removeDocumentError,
-    templateName: Templates.REMOVE_DOCUMENT,
   });
 };

--- a/src/modules/sdk/objections/types.ts
+++ b/src/modules/sdk/objections/types.ts
@@ -61,7 +61,7 @@ export interface Objection {
     name: string;
   }>,
   created_by: CreatedBy,
-  reason: string;
+  reason?: string;
 }
 
 export interface CreatedBy {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -24,7 +24,7 @@ export const router: Router = Router();
  * @param template the template name
  */
 const renderTemplate = (template: string) => (req: Request, res: Response) => {
-  return res.render(template, { templateName: template });
+  return res.render(template);
 };
 
 router.get("/", indexRoute.get);

--- a/test/controller/document_upload/html.upload.responder.strategy.spec.unit.ts
+++ b/test/controller/document_upload/html.upload.responder.strategy.spec.unit.ts
@@ -59,7 +59,6 @@ describe("html upload responder tests", () => {
       attachments,
       documentUploadErr: errorData,
       errorList: [errorData],
-      templateName: Templates.DOCUMENT_UPLOAD,
     });
   });
 });

--- a/test/controller/enter.information.controller.spec.unit.ts
+++ b/test/controller/enter.information.controller.spec.unit.ts
@@ -76,6 +76,21 @@ describe("enter information tests", () => {
 
     expect(response.status).toEqual(200);
     expect(response.text).toContain("Tell us why");
+    expect(response.text).not.toContain(REASON);
+  });
+
+  it("should render the page with existing information when present", async () => {
+    mockRetrieveFromObjectionSession.mockReset();
+    mockGetObjection.mockReset().mockResolvedValueOnce(mockObjectionWithReason);
+
+    const response = await request(app).get(OBJECTIONS_ENTER_INFORMATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(response.status).toEqual(200);
+    expect(mockGetObjection).toHaveBeenCalledTimes(1);
+    expect(response.text).toContain("Tell us why");
+    expect(response.text).toContain(REASON);
   });
 
   it("should redirect to the document-upload page on post and change flag undefined", async () => {
@@ -94,20 +109,6 @@ describe("enter information tests", () => {
 
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_DOCUMENT_UPLOAD);
-  });
-
-  it("should render the page with existing information when present", async () => {
-    mockRetrieveFromObjectionSession.mockReset();
-    mockGetObjection.mockReset().mockResolvedValueOnce(mockObjection);
-
-    const response = await request(app).get(OBJECTIONS_ENTER_INFORMATION)
-      .set("Referer", "/")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
-
-    expect(response.status).toEqual(200);
-    expect(mockGetObjection).toHaveBeenCalledTimes(1);
-    expect(response.text).toContain("Tell us why");
-    expect(response.text).toContain(REASON);
   });
 
   it("should throw an error when no session is present", async () => {
@@ -152,7 +153,7 @@ describe("enter information tests", () => {
     mockRetrieveFromObjectionSession.mockReset().mockReturnValueOnce("objectionId");
     mockRetrieveFromObjectionSession.mockReturnValueOnce(true);
     mockGetObjectionSessionValue.mockImplementationOnce(() => dummyCompanyProfile);
-    mockGetObjection.mockReset().mockResolvedValueOnce(mockObjection);
+    mockGetObjection.mockReset().mockResolvedValueOnce(mockObjectionWithReason);
 
     const response = await request(app).post(OBJECTIONS_ENTER_INFORMATION)
       .set("Referer", "/")
@@ -231,6 +232,20 @@ const dummyCompanyProfile: ObjectionCompanyProfile = {
 };
 
 const mockObjection: Objection = {
+  attachments: [
+    {
+      name: "attachment.jpg",
+    },
+    {
+      name: "document.pdf",
+    }],
+  created_by: {
+    full_name: "name",
+    share_identity: false
+  },
+};
+
+const mockObjectionWithReason: Objection = {
   attachments: [
     {
       name: "attachment.jpg",

--- a/views/download.html
+++ b/views/download.html
@@ -25,3 +25,9 @@
     </div>
   </div>
 {% endblock %}
+
+{% block bodyEnd %}
+  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
+  <script src="{{assetPath}}/javascripts/govuk-frontend/v3.6.0/govuk-frontend-3.6.0.min.js"></script>
+  <script>window.GOVUKFrontend.initAll()</script>
+{% endblock %}

--- a/views/includes/piwik-scripts.html
+++ b/views/includes/piwik-scripts.html
@@ -1,0 +1,11 @@
+<script src="{{assetPath}}/javascripts/app/piwik-enable.js"></script>
+<script type="application/javascript">
+    (function() {
+        bindPiwikListener('strike-off-objections', '{{PIWIK_URL}}', {{PIWIK_SITE_ID}});
+    }());
+</script>
+<noscript>
+    <p>
+        <img src="{{PIWIK_URL}}/piwik.php?idsite={{PIWIK_SITE_ID}}" style="border:0;" alt="" />
+    </p>
+</noscript>

--- a/views/layout.html
+++ b/views/layout.html
@@ -94,15 +94,5 @@
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="{{assetPath}}/javascripts/govuk-frontend/v3.6.0/govuk-frontend-3.6.0.min.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
-  <script src="{{assetPath}}/javascripts/app/piwik-enable.js"></script>
-  <script type="application/javascript">
-    (function() {
-      bindPiwikListener('strike-off-objections', '{{PIWIK_URL}}', {{PIWIK_SITE_ID}});
-    }());
-  </script>
-  <noscript>
-    <p>
-      <img src="{{PIWIK_URL}}/piwik.php?idsite={{PIWIK_SITE_ID}}" style="border:0;" alt="" />
-    </p>
-  </noscript>
+  {% include "includes/piwik-scripts.html" %}
 {% endblock %}


### PR DESCRIPTION
Moved Piwik scripts to an includes, placed that in the layout and then overwrote the layout endblock on the download.html

One thing I noticed is that for matomo to work we no longer need to pass in the templateName in the render. This is the reason download was being picked up when templateName wasn't part of the render options. We can either remove all of the templateName's from the service as part of this or raise it with Sarah as part of a future change.