### PR TITLE
obj-447 gaz2 requested or issued show notice expired message

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -4,7 +4,7 @@ import ObjectionCompanyProfile from "model/objection.company.profile";
 import { SESSION_OBJECTION_ID } from "../constants";
 import { OBJECTIONS_ENTER_INFORMATION, OBJECTIONS_NO_STRIKE_OFF, OBJECTIONS_NOTICE_EXPIRED } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
-import { CompanyEligibility, EligibilityStatus, ObjectionCreate, ObjectionStatus } from "../modules/sdk/objections";
+import { EligibilityStatus, ObjectionCreate, ObjectionStatus } from "../modules/sdk/objections";
 import { createNewObjection, getCompanyEligibility } from "../services/objection.service";
 import {
   addToObjectionSession,
@@ -41,12 +41,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       const token: string = retrieveAccessTokenFromSession(session);
 
       let latestGaz1Date: string;
-      const companyEligibility: CompanyEligibility = await getCompanyEligibility(company.companyNumber, token);
+      const { eligibility_status } = await getCompanyEligibility(company.companyNumber, token);
 
-      if (companyEligibility.eligibility_status === EligibilityStatus.ELIGIBLE) {
+      if (eligibility_status === EligibilityStatus.ELIGIBLE) {
         latestGaz1Date = await getLatestGaz1Date(company.companyNumber, token);
-      } else if (companyEligibility.eligibility_status === EligibilityStatus.INELIGIBLE_GAZ2_REQUESTED ||
-                 companyEligibility.eligibility_status === EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF) {
+      } else if (eligibility_status === EligibilityStatus.INELIGIBLE_GAZ2_REQUESTED ||
+                 eligibility_status === EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF) {
         latestGaz1Date = "Notice expired";
       } else {
         latestGaz1Date = "No notice in The Gazette";

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -42,9 +42,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
       let latestGaz1Date: string;
       const companyEligibility: CompanyEligibility = await getCompanyEligibility(company.companyNumber, token);
-      if (companyEligibility.eligibility_status === EligibilityStatus.ELIGIBLE ||
-        companyEligibility.eligibility_status === EligibilityStatus.INELIGIBLE_GAZ2_REQUESTED) {
+
+      if (companyEligibility.eligibility_status === EligibilityStatus.ELIGIBLE) {
         latestGaz1Date = await getLatestGaz1Date(company.companyNumber, token);
+      } else if (companyEligibility.eligibility_status === EligibilityStatus.INELIGIBLE_GAZ2_REQUESTED ||
+                 companyEligibility.eligibility_status === EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF) {
+        latestGaz1Date = "Notice expired";
       } else {
         latestGaz1Date = "No notice in The Gazette";
       }

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -256,13 +256,14 @@ describe("confirm company tests", () => {
     expect(response.text).toContain("14 April 2015");
   });
 
-  it("should correctly display the latest GAZ1 date from the filing history if company in gaz1, with gaz2 requested", async () => {
+  it("should correctly display the notice expired message from the filing history if company in gaz1, with gaz2 requested", async () => {
 
     const mockValidAccessToken = retrieveAccessTokenFromSession as jest.Mock;
     mockValidAccessToken.mockReset().mockImplementation(() => ACCESS_TOKEN);
 
     mockGetObjectionSessionValue.mockReset().mockImplementation(() => dummyCompanyProfile);
 
+    mockGetCompanyEligibility.mockReset();
     mockGetCompanyEligibility.mockReset().mockImplementation(() => dummyCompanyEligibilityIneligibleGaz2Requested);
 
     mockLatestGaz1FilingHistoryItem.mockResolvedValueOnce(dummyFilingHistoryItem);
@@ -275,7 +276,28 @@ describe("confirm company tests", () => {
     expect(response.status).toEqual(200);
 
     expect(response.text).toContain("00006400");
-    expect(response.text).toContain("14 April 2015");
+    expect(response.text).toContain("Notice expired");
+  });
+
+  it("should correctly display the notice expired message from the filing history if company is INELIGIBLE_COMPANY_STRUCK_OFF", async () => {
+
+    const mockValidAccessToken = retrieveAccessTokenFromSession as jest.Mock;
+    mockValidAccessToken.mockReset().mockImplementation(() => ACCESS_TOKEN);
+
+    mockGetObjectionSessionValue.mockReset().mockImplementation(() => dummyCompanyProfile);
+
+    mockGetCompanyEligibility.mockReset();
+    mockGetCompanyEligibility.mockReset().mockImplementation(() => dummyCompanyEligibilityIneligibleStruckOff);
+
+    const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(mockGetObjectionSessionValue).toHaveBeenCalledTimes(1);
+    expect(response.status).toEqual(200);
+
+    expect(response.text).toContain("00006400");
+    expect(response.text).toContain("Notice expired");
   });
 
   it("should render the strike off expired page when an objection is created with the status INELIGIBLE_GAZ2_REQUESTED", async () => {
@@ -296,6 +318,7 @@ describe("confirm company tests", () => {
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NOTICE_EXPIRED);
   });
+
 });
 
 const dummyCompanyProfile: ObjectionCompanyProfile = {
@@ -352,4 +375,9 @@ const dummyCompanyEligibility: CompanyEligibility = {
 const dummyCompanyEligibilityIneligibleGaz2Requested: CompanyEligibility = {
   is_eligible: false,
   eligibility_status: EligibilityStatus.INELIGIBLE_GAZ2_REQUESTED,
+};
+
+const dummyCompanyEligibilityIneligibleStruckOff: CompanyEligibility = {
+  is_eligible: false,
+  eligibility_status: EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF,
 };

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -263,7 +263,6 @@ describe("confirm company tests", () => {
 
     mockGetObjectionSessionValue.mockReset().mockImplementation(() => dummyCompanyProfile);
 
-    mockGetCompanyEligibility.mockReset();
     mockGetCompanyEligibility.mockReset().mockImplementation(() => dummyCompanyEligibilityIneligibleGaz2Requested);
 
     mockLatestGaz1FilingHistoryItem.mockResolvedValueOnce(dummyFilingHistoryItem);
@@ -286,7 +285,6 @@ describe("confirm company tests", () => {
 
     mockGetObjectionSessionValue.mockReset().mockImplementation(() => dummyCompanyProfile);
 
-    mockGetCompanyEligibility.mockReset();
     mockGetCompanyEligibility.mockReset().mockImplementation(() => dummyCompanyEligibilityIneligibleStruckOff);
 
     const response = await request(app).get(OBJECTIONS_CONFIRM_COMPANY)


### PR DESCRIPTION
Confirm this is the correct company screen will display ‘Notice expired’ if either:
EligibilityStatus.INELIGIBLE_GAZ2_REQUESTED 
EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF

are returned.