### PR TITLE
OBJ-462 amending wording on notice expired page

### DIFF
--- a/test/controller/notice.expired.controller.spec.unit.ts
+++ b/test/controller/notice.expired.controller.spec.unit.ts
@@ -51,7 +51,7 @@ describe("notice expired tests", () => {
       .get("/strike-off-objections/notice-expired");
 
     expect(response.status).toEqual(200);
-    expect(response.text).toMatch(/The strike off notice has expired for the company/);
+    expect(response.text).toMatch(/It's too late to object to the company being struck off/);
     expect(response.text).toMatch(/Girls school trust/);
   });
 

--- a/test/routes/routes.spec.unit.ts
+++ b/test/routes/routes.spec.unit.ts
@@ -134,7 +134,7 @@ describe("Basic URL Tests", () => {
       .get("/strike-off-objections/notice-expired");
 
     expect(response.status).toEqual(200);
-    expect(response.text).toMatch(/The strike off notice has expired for the company/);
+    expect(response.text).toMatch(/It's too late to object to the company being struck off/);
   });
 
   it("should find the no strike off page", async () => {

--- a/views/notice-expired.html
+++ b/views/notice-expired.html
@@ -8,10 +8,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        The strike off notice has expired for the company
+        It's too late to object to the company being struck off
       </h1>
-      <p class="govuk-body-l">{{ companyName }}
-        has been struck off the register and you can no longer apply to make an objection.</p>
+      <p>The strike off notice for {{ companyName }} has expired. You can no longer apply to make an objection.</p>
       <p>
         <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening">Contact us</a>
         if you think this information is wrong.</p>


### PR DESCRIPTION
Text changes to the title and first sentence of the notice expired page. Removed the govuk-body-l class as the screenshot doesn't show the first line to be any different to the text on the rest of the page.