### PR TITLE
OBJ-505 error screen displays when using back button

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -8,7 +8,6 @@ import { EligibilityStatus, ObjectionCreate, ObjectionStatus } from "../modules/
 import { createNewObjection, getCompanyEligibility } from "../services/objection.service";
 import {
   addToObjectionSession,
-  deleteObjectionCreateFromObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
   retrieveObjectionCreateFromObjectionSession

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -75,7 +75,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     const ineligiblePage = getIneligiblePage(objectionStatus);
     if (ineligiblePage) {
-      deleteObjectionCreateFromObjectionSession(session);
       logger.info(`Objection status is ${objectionStatus} for objection id ${objectionId}, company ${companyNumber},`
         + ` redirecting user to ${ineligiblePage}`);
       return res.redirect(ineligiblePage);
@@ -84,7 +83,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
     return res.redirect(OBJECTIONS_ENTER_INFORMATION);
   } catch (e) {
-    deleteObjectionCreateFromObjectionSession(session);
     return next(e);
   }
 };

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -34,7 +34,6 @@ import { getLatestGaz1FilingHistoryItem } from "../../src/services/company.filin
 import { createNewObjection, getCompanyEligibility } from "../../src/services/objection.service";
 import {
   addToObjectionSession,
-  deleteObjectionCreateFromObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
   retrieveObjectionCreateFromObjectionSession
@@ -49,7 +48,6 @@ const SESSION: Session = {
 
 const mockGetObjectionSessionValue = retrieveCompanyProfileFromObjectionSession as jest.Mock;
 const mockGetObjectCreate = retrieveObjectionCreateFromObjectionSession as jest.Mock;
-const mockDeleteObjectCreate = deleteObjectionCreateFromObjectionSession as jest.Mock;
 
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
@@ -134,7 +132,6 @@ describe("confirm company tests", () => {
   });
 
   it("should render the notice expired page when an objection is created with the status INELIGIBLE_COMPANY_STRUCK_OFF", async () => {
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -147,13 +144,11 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NOTICE_EXPIRED);
   });
 
   it("should render the no strike off page when an objection is created with the status INELIGIBLE_NO_DISSOLUTION_ACTION", async () => {
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -166,7 +161,6 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NO_STRIKE_OFF);
   });
@@ -183,7 +177,6 @@ describe("confirm company tests", () => {
 
     const ERROR_500 = "Sorry, there is a problem with the service";
 
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -198,7 +191,6 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(500);
     expect(response.text).toContain(ERROR_500);
   });
@@ -299,7 +291,6 @@ describe("confirm company tests", () => {
   });
 
   it("should render the strike off expired page when an objection is created with the status INELIGIBLE_GAZ2_REQUESTED", async () => {
-    mockDeleteObjectCreate.mockReset();
     mockGetObjectionSessionValue.mockReset();
     mockGetObjectionSessionValue.mockImplementation(() => dummyCompanyProfile);
 
@@ -312,7 +303,6 @@ describe("confirm company tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockDeleteObjectCreate).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_NOTICE_EXPIRED);
   });


### PR DESCRIPTION
Removing deleteObjectionCreate calls from the confirm company methods. The objectionCreate is still deleted later on when the customer confirms.