### PR TITLE
Resolve msgpack5 security vulnerabiltity 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6082,9 +6082,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msgpack5": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-4.2.1.tgz",
-      "integrity": "sha512-Xo7nE9ZfBVonQi1rSopNAqPdts/QHyuSEUwIEzAkB+V2FtmkkLUbP6MyVqVVQxsZYI65FpvW3Bb8Z9ZWEjbgHQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-4.5.1.tgz",
+      "integrity": "sha512-zC1vkcliryc4JGlL6OfpHumSYUHWFGimSI+OgfRCjTFLmKA2/foR9rMTOhWiqfOrfxJOctrpWPvrppf8XynJxw==",
       "requires": {
         "bl": "^2.0.1",
         "inherits": "^2.0.3",


### PR DESCRIPTION
Changing msgpack5 version from 4.2.1 to 4.5.1 to resolve a security vulnerability picked up by depandabot

Resolves: [BI-7339](https://companieshouse.atlassian.net/browse/BI-7339)