### PR TITLE
Adding choose a different company link onto the confirm company screen

### DIFF
--- a/views/confirm-company.html
+++ b/views/confirm-company.html
@@ -95,6 +95,9 @@
           }
         }) }}
       </form>
+      <p>
+        <a class="govuk-link" href="/strike-off-objections/company-number">Choose a different company</a>
+      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Adding 'Choose a different company' link onto the confirm company screen to redirect the user back to the enter a company number screen.

Resolves: [OBJ-457](https://companieshouse.atlassian.net/browse/OBJ-457)