### PR TITLE
Creating a skeleton design page for objector type selection

### DIFF
--- a/src/model/page.urls.ts
+++ b/src/model/page.urls.ts
@@ -26,6 +26,7 @@ export const CONFIRMATION: string = SEPARATOR + Templates.CONFIRMATION;
 export const CHANGE_ANSWERS: string = SEPARATOR + "change-answers";
 export const ERROR: string = SEPARATOR + Templates.ERROR;
 export const ACCESSIBILITY_STATEMENT: string = SEPARATOR + Templates.ACCESSIBILITY_STATEMENT;
+export const OBJECTOR_ORGANISATION: string = SEPARATOR + Templates.OBJECTOR_ORGANISATION_PAGE;
 
 /**
  * URLs for redirects will need to start with the application name
@@ -43,3 +44,4 @@ export const OBJECTIONS_CHECK_YOUR_ANSWERS: string = STRIKE_OFF_OBJECTIONS + CHE
 export const OBJECTIONS_CONFIRMATION: string = STRIKE_OFF_OBJECTIONS + CONFIRMATION;
 export const OBJECTIONS_CHANGE_ANSWERS: string = STRIKE_OFF_OBJECTIONS + CHANGE_ANSWERS;
 export const OBJECTIONS_ERROR: string = STRIKE_OFF_OBJECTIONS + ERROR;
+export const OBJECTIONS_OBJECTOR_ORGANISATION: string = STRIKE_OFF_OBJECTIONS + OBJECTOR_ORGANISATION;

--- a/src/model/template.paths.ts
+++ b/src/model/template.paths.ts
@@ -1,5 +1,3 @@
-import { OBJECTIONS_OBJECTOR_ORGANISATION } from "./page.urls";
-
 export enum Templates {
   OBJECTING_ENTITY_NAME = "objecting-entity-name",
   COMPANY_NUMBER = "company-number",

--- a/src/model/template.paths.ts
+++ b/src/model/template.paths.ts
@@ -1,3 +1,5 @@
+import { OBJECTIONS_OBJECTOR_ORGANISATION } from "./page.urls";
+
 export enum Templates {
   OBJECTING_ENTITY_NAME = "objecting-entity-name",
   COMPANY_NUMBER = "company-number",
@@ -18,5 +20,6 @@ export enum Templates {
   ERROR = "error",
   FILE_ERROR = "file-error",
   ACCESSIBILITY_STATEMENT = "accessibility-statement",
-  ERROR_404 = "page-not-found"
+  ERROR_404 = "page-not-found",
+  OBJECTOR_ORGANISATION_PAGE = "objector-organisation"
 }

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -67,3 +67,5 @@ router.get(pageURLs.ERROR, renderTemplate(Templates.ERROR));
 router.get(pageURLs.CHANGE_ANSWERS, changeAnswersRoute.get);
 
 router.get(pageURLs.ACCESSIBILITY_STATEMENT, renderTemplate(Templates.ACCESSIBILITY_STATEMENT));
+
+router.get(pageURLs.OBJECTOR_ORGANISATION, renderTemplate(Templates.OBJECTOR_ORGANISATION_PAGE));

--- a/views/objector-organisation.html
+++ b/views/objector-organisation.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  {% if errorList.length > 0 %}
+    Error:
+  {% endif %}
+  Apply to object to a company being struck off
+{% endblock %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/strike-off-objections"
+  }) }}
+{% endblock %}
+
+{% block content %}
+    {{ govukRadios({
+        idPrefix: "objector-organisation",
+        name: "objector-organisation",
+        fieldset: {
+          legend: {
+            text: "Who is applying to object?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            value: "myself-or-company",
+            text: "I'm objecting for myself, or a company I work for"
+          },
+          {
+            value: "client",
+            text: "I'm objecting on behalf of a client"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+{% endblock %}


### PR DESCRIPTION
Creating a skeleton design page for objector type selection.
This page does not contain any functionality.
Only necessary information like route and paths added.

Resolves: [OBJ-511](https://companieshouse.atlassian.net/browse/OBJ-511)