### PR TITLE
Feature/obj 438 update objecting entity name page based on objector selected

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const CHANGE_ANSWER_KEY = "change";
 
 
 export const FULL_NAME_FIELD = "fullName";
-export const DIVULGE_INFO_FIELD = "shareIdentity";
+export const SHARE_IDENTITY_FIELD = "shareIdentity";
 export const GENERIC_INFO = "generic";
 export const OBJECTOR_FIELDS = {
   "myself-or-company": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,7 @@
+import {
+  OBJECTIONS_OBJECTOR_ORGANISATION,
+  STRIKE_OFF_OBJECTIONS } from "./model/page.urls";
+
 export const APP_NAME = "strike-off-objections-web";
 export const OBJECTIONS_SESSION_NAME = "strike_off_objections_session";
 export const SESSION_COMPANY_PROFILE = "objections_company_profile";
@@ -5,3 +9,25 @@ export const SESSION_OBJECTION_CREATE = "objection_create";
 export const SESSION_OBJECTION_ID = "objection_id";
 export const SESSION_OBJECTOR = "objector";
 export const CHANGE_ANSWER_KEY = "change";
+
+
+export const FULL_NAME_FIELD = "fullName";
+export const DIVULGE_INFO_FIELD = "shareIdentity";
+export const GENERIC_INFO = "generic";
+export const OBJECTOR_FIELDS = {
+  "myself-or-company": {
+    textFullName: "Tell us your name, or the name of the company you work for",
+    textSharedIdentity: "Can we share the name and email address with the company if they request that information?",
+    backLink: OBJECTIONS_OBJECTOR_ORGANISATION
+  },
+  "client": {
+    textFullName: "What is the name of your organisation?",
+    textSharedIdentity: "Can we share the name of your organisation and your email address with the company if they request that information?",
+    backLink: OBJECTIONS_OBJECTOR_ORGANISATION
+  },
+  [GENERIC_INFO]: {
+    textFullName: "What is your full name or the name of your organisation?",
+    textSharedIdentity: "Can we share your name and email address with the company if they request that information?",
+    backLink: STRIKE_OFF_OBJECTIONS
+  },
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,4 +3,5 @@ export const OBJECTIONS_SESSION_NAME = "strike_off_objections_session";
 export const SESSION_COMPANY_PROFILE = "objections_company_profile";
 export const SESSION_OBJECTION_CREATE = "objection_create";
 export const SESSION_OBJECTION_ID = "objection_id";
+export const SESSION_OBJECTOR = "objector";
 export const CHANGE_ANSWER_KEY = "change";

--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -2,7 +2,11 @@ import { NextFunction, Request, Response } from "express";
 import { check, Result, ValidationError, validationResult } from "express-validator";
 import { ErrorMessages } from "../model/error.messages";
 import { createGovUkErrorData, GovUkErrorData } from "../model/govuk.error.data";
-import { OBJECTIONS_CHECK_YOUR_ANSWERS, OBJECTIONS_COMPANY_NUMBER } from "../model/page.urls";
+import {
+  OBJECTIONS_CHECK_YOUR_ANSWERS,
+  OBJECTIONS_COMPANY_NUMBER,
+  OBJECTIONS_OBJECTOR_ORGANISATION,
+  STRIKE_OFF_OBJECTIONS } from "../model/page.urls";
 import {
   addObjectionCreateToObjectionSession,
   retrieveAccessTokenFromSession,
@@ -24,18 +28,21 @@ import ObjectionCompanyProfile from "../model/objection.company.profile";
 const FULL_NAME_FIELD = "fullName";
 const DIVULGE_INFO_FIELD = "shareIdentity";
 
-const TEXTS_FIELD = {
+const OBJECTOR_FIELDS = {
   "myself-or-company": {
     textFullName: "Tell us your name, or the name of the company you work for",
     textSharedIdentity: "Can we share the name and email address with the company if they request that information?",
+    backLink: OBJECTIONS_OBJECTOR_ORGANISATION
   },
   "client": {
     textFullName: "What is the name of your organisation?",
     textSharedIdentity: "Can we share the name of your organisation and your email address with the company if they request that information?",
+    backLink: OBJECTIONS_OBJECTOR_ORGANISATION
   },
   "generic": {
     textFullName: "What is your full name or the name of your organisation?",
     textSharedIdentity: "Can we share your name and email address with the company if they request that information?",
+    backLink: STRIKE_OFF_OBJECTIONS
   },
 };
 
@@ -62,7 +69,7 @@ const showPageWithSessionDataIfPresent = (session: Session, res: Response) => {
     fullNameValue: existingName,
     isYesChecked: yesChecked,
     isNoChecked: noChecked,
-    ...TEXTS_FIELD[objectorOrganisation]
+    ...OBJECTOR_FIELDS[objectorOrganisation]
   });
 
 };
@@ -79,7 +86,7 @@ const showPageWithMongoData = async (session: Session, res: Response, next: Next
         fullNameValue: existingName,
         isYesChecked: existingShareIdentity,
         isNoChecked: !existingShareIdentity,
-        ...TEXTS_FIELD[objectorOrganisation]
+        ...OBJECTOR_FIELDS[objectorOrganisation]
       });
     } else {
       return next(new Error("Existing data not present"));
@@ -184,6 +191,6 @@ const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
     shareIdentityErr,
     errorList: errorListData,
     objectingEntityNameErr,
-    ...TEXTS_FIELD[objectorOrganisation]
+    ...OBJECTOR_FIELDS[objectorOrganisation]
   });
 };

--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -20,6 +20,21 @@ import ObjectionCompanyProfile from "../model/objection.company.profile";
 const FULL_NAME_FIELD = "fullName";
 const DIVULGE_INFO_FIELD = "shareIdentity";
 
+const TEXTS_FIELD = {
+  "myself-or-company": {
+    textFullName: "Tell us your name, or the name of the company you work for",
+    textSharedIdentity: "Can we share the name and email address with the company if they request that information?",
+  },
+  client: {
+    textFullName: "What is the name of your organisation?",
+    textSharedIdentity: "Can we share the name of your organisation and your email address with the company if they request that information?",
+  },
+  generic: {
+    textFullName: "What is your full name or the name of your organisation?",
+    textSharedIdentity: "Can we share your name and email address with the company if they request that information?",
+  },
+};
+
 const validators = [
   check(FULL_NAME_FIELD).not().isEmpty().withMessage(ErrorMessages.ENTER_NAME),
   check(DIVULGE_INFO_FIELD).not().isEmpty().withMessage(ErrorMessages.SELECT_TO_DIVULGE),
@@ -41,6 +56,7 @@ const showPageWithSessionDataIfPresent = (session: Session, res: Response) => {
     fullNameValue: existingName,
     isYesChecked: yesChecked,
     isNoChecked: noChecked,
+    ...TEXTS_FIELD.generic
   });
 };
 
@@ -54,6 +70,7 @@ const showPageWithMongoData = async (session: Session, res: Response, next: Next
         fullNameValue: existingName,
         isYesChecked: existingShareIdentity,
         isNoChecked: !existingShareIdentity,
+        ...TEXTS_FIELD.generic
       });
     } else {
       return next(new Error("Existing data not present"));
@@ -154,5 +171,6 @@ const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
     shareIdentityErr,
     errorList: errorListData,
     objectingEntityNameErr,
+    ...TEXTS_FIELD.generic
   });
 };

--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -18,7 +18,7 @@ import { getObjection, updateObjectionUserDetails } from "../services/objection.
 import logger from "../utils/logger";
 import {
   CHANGE_ANSWER_KEY,
-  DIVULGE_INFO_FIELD,
+  SHARE_IDENTITY_FIELD,
   FULL_NAME_FIELD,
   GENERIC_INFO,
   OBJECTOR_FIELDS,
@@ -29,7 +29,7 @@ import ObjectionCompanyProfile from "../model/objection.company.profile";
 
 const validators = [
   check(FULL_NAME_FIELD).not().isEmpty().withMessage(ErrorMessages.ENTER_NAME),
-  check(DIVULGE_INFO_FIELD).not().isEmpty().withMessage(ErrorMessages.SELECT_TO_DIVULGE),
+  check(SHARE_IDENTITY_FIELD).not().isEmpty().withMessage(ErrorMessages.SELECT_TO_DIVULGE),
 ];
 
 const showPageWithSessionDataIfPresent = (session: Session, res: Response) => {
@@ -155,7 +155,7 @@ const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
           case FULL_NAME_FIELD:
             objectingEntityNameErr = govUkErrorData;
             break;
-          case DIVULGE_INFO_FIELD:
+          case SHARE_IDENTITY_FIELD:
             shareIdentityErr = govUkErrorData;
             break;
       }

--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -4,9 +4,7 @@ import { ErrorMessages } from "../model/error.messages";
 import { createGovUkErrorData, GovUkErrorData } from "../model/govuk.error.data";
 import {
   OBJECTIONS_CHECK_YOUR_ANSWERS,
-  OBJECTIONS_COMPANY_NUMBER,
-  OBJECTIONS_OBJECTOR_ORGANISATION,
-  STRIKE_OFF_OBJECTIONS } from "../model/page.urls";
+  OBJECTIONS_COMPANY_NUMBER } from "../model/page.urls";
 import {
   addObjectionCreateToObjectionSession,
   retrieveAccessTokenFromSession,
@@ -20,31 +18,14 @@ import { getObjection, updateObjectionUserDetails } from "../services/objection.
 import logger from "../utils/logger";
 import {
   CHANGE_ANSWER_KEY,
+  DIVULGE_INFO_FIELD,
+  FULL_NAME_FIELD,
+  GENERIC_INFO,
+  OBJECTOR_FIELDS,
   SESSION_OBJECTION_CREATE,
   SESSION_OBJECTION_ID,
   SESSION_OBJECTOR } from "../constants";
 import ObjectionCompanyProfile from "../model/objection.company.profile";
-
-const FULL_NAME_FIELD = "fullName";
-const DIVULGE_INFO_FIELD = "shareIdentity";
-
-const OBJECTOR_FIELDS = {
-  "myself-or-company": {
-    textFullName: "Tell us your name, or the name of the company you work for",
-    textSharedIdentity: "Can we share the name and email address with the company if they request that information?",
-    backLink: OBJECTIONS_OBJECTOR_ORGANISATION
-  },
-  "client": {
-    textFullName: "What is the name of your organisation?",
-    textSharedIdentity: "Can we share the name of your organisation and your email address with the company if they request that information?",
-    backLink: OBJECTIONS_OBJECTOR_ORGANISATION
-  },
-  "generic": {
-    textFullName: "What is your full name or the name of your organisation?",
-    textSharedIdentity: "Can we share your name and email address with the company if they request that information?",
-    backLink: STRIKE_OFF_OBJECTIONS
-  },
-};
 
 const validators = [
   check(FULL_NAME_FIELD).not().isEmpty().withMessage(ErrorMessages.ENTER_NAME),
@@ -56,7 +37,7 @@ const showPageWithSessionDataIfPresent = (session: Session, res: Response) => {
   let yesChecked: boolean = false;
   let noChecked: boolean = false;
   const objectionCreate: ObjectionCreate = retrieveFromObjectionSession(session, SESSION_OBJECTION_CREATE);
-  const objectorOrganisation = retrieveFromObjectionSession(session, SESSION_OBJECTOR) || "generic";
+  const objectorOrganisation = retrieveFromObjectionSession(session, SESSION_OBJECTOR) || GENERIC_INFO;
 
   if (objectionCreate) {
     existingName = objectionCreate.full_name;
@@ -79,7 +60,7 @@ const showPageWithMongoData = async (session: Session, res: Response, next: Next
     const objection: Objection = await getObjection(session);
     const existingName: string = objection.created_by.full_name;
     const existingShareIdentity: boolean = objection.created_by.share_identity;
-    const objectorOrganisation = retrieveFromObjectionSession(session, SESSION_OBJECTOR) || "generic";
+    const objectorOrganisation = retrieveFromObjectionSession(session, SESSION_OBJECTOR) || GENERIC_INFO;
 
     if (existingName && existingShareIdentity !== undefined) {
       return res.render(Templates.OBJECTING_ENTITY_NAME, {
@@ -182,7 +163,7 @@ const showErrorsOnScreen = (errors: Result, req: Request, res: Response) => {
     });
 
   const fullNameValue: string = req.body.fullName;
-  const objectorOrganisation = retrieveFromObjectionSession(req.session as Session, SESSION_OBJECTOR) || "generic";
+  const objectorOrganisation = retrieveFromObjectionSession(req.session as Session, SESSION_OBJECTOR) || GENERIC_INFO;
 
   return res.render(Templates.OBJECTING_ENTITY_NAME, {
     fullNameValue,

--- a/src/controllers/objector.organisation.controller.ts
+++ b/src/controllers/objector.organisation.controller.ts
@@ -2,18 +2,22 @@ import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
 import { GovUkErrorData } from "model/govuk.error.data";
 
-import { objectorOrganisation } from "../validation";
+import { Session } from "@companieshouse/node-session-handler";
 
+import { objectorOrganisation } from "../validation";
 import { OBJECTIONS_OBJECTING_ENTITY_NAME } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
 
 import logger from "../utils/logger";
+import { addToObjectionSession } from "../services/objection.session.service";
+import { SESSION_OBJECTOR } from "../constants";
 
 const postObjectorOrganisation = (req: Request, res: Response, next: NextFunction) => {
   try {
     const errors = validationResult(req);
 
     if (errors.isEmpty()) {
+      addToObjectionSession(req.session as Session, SESSION_OBJECTOR, req.body["objector-organisation"]);
       return res.redirect(OBJECTIONS_OBJECTING_ENTITY_NAME);
     }
 

--- a/src/controllers/objector.organisation.controller.ts
+++ b/src/controllers/objector.organisation.controller.ts
@@ -9,8 +9,21 @@ import { OBJECTIONS_OBJECTING_ENTITY_NAME } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
 
 import logger from "../utils/logger";
-import { addToObjectionSession } from "../services/objection.session.service";
+import { addToObjectionSession, retrieveFromObjectionSession } from "../services/objection.session.service";
 import { SESSION_OBJECTOR } from "../constants";
+
+export const get = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const objectorOrganisation = retrieveFromObjectionSession(req.session as Session, SESSION_OBJECTOR);
+    res.render(Templates.OBJECTOR_ORGANISATION_PAGE, {
+      isMyselfOrCompanyChecked: objectorOrganisation === "myself-or-company",
+      isClientChecked: objectorOrganisation === "client"
+    });
+  } catch (e) {
+    logger.error(e.message);
+    return next(e);
+  }
+};
 
 const postObjectorOrganisation = (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/src/controllers/objector.organisation.controller.ts
+++ b/src/controllers/objector.organisation.controller.ts
@@ -14,10 +14,10 @@ import { SESSION_OBJECTOR } from "../constants";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
-    const objectorOrganisation = retrieveFromObjectionSession(req.session as Session, SESSION_OBJECTOR);
+    const objectorOrganisationField = retrieveFromObjectionSession(req.session as Session, SESSION_OBJECTOR);
     res.render(Templates.OBJECTOR_ORGANISATION_PAGE, {
-      isMyselfOrCompanyChecked: objectorOrganisation === "myself-or-company",
-      isClientChecked: objectorOrganisation === "client"
+      isMyselfOrCompanyChecked: objectorOrganisationField === "myself-or-company",
+      isClientChecked: objectorOrganisationField === "client"
     });
   } catch (e) {
     logger.error(e.message);

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -69,5 +69,5 @@ router.get(pageURLs.CHANGE_ANSWERS, changeAnswersRoute.get);
 
 router.get(pageURLs.ACCESSIBILITY_STATEMENT, renderTemplate(Templates.ACCESSIBILITY_STATEMENT));
 
-router.get(pageURLs.OBJECTOR_ORGANISATION, renderTemplate(Templates.OBJECTOR_ORGANISATION_PAGE));
+router.get(pageURLs.OBJECTOR_ORGANISATION, objectorOrganisation.get);
 router.post(pageURLs.OBJECTOR_ORGANISATION, objectorOrganisation.post);

--- a/test/controller/objecting.entity.name.controller.spec.unit.ts
+++ b/test/controller/objecting.entity.name.controller.spec.unit.ts
@@ -75,7 +75,7 @@ describe("objecting entity name tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(3);
     expect(mockRetrieveObjectionSessionFromSession).not.toBeCalled();
     expect(mockGetObjection).not.toBeCalled();
     expect(response.status).toEqual(200);
@@ -92,7 +92,7 @@ describe("objecting entity name tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(3);
     expect(mockRetrieveObjectionSessionFromSession).not.toBeCalled();
     expect(mockGetObjection).not.toBeCalled();
     expect(response.status).toEqual(200);
@@ -109,7 +109,7 @@ describe("objecting entity name tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(3);
     expect(mockRetrieveObjectionSessionFromSession).not.toBeCalled();
     expect(mockGetObjection).not.toBeCalled();
     expect(response.status).toEqual(200);
@@ -126,7 +126,7 @@ describe("objecting entity name tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(3);
     expect(mockRetrieveObjectionSessionFromSession).not.toBeCalled();
     expect(mockGetObjection).not.toBeCalled();
     expect(response.status).toEqual(200);
@@ -146,7 +146,7 @@ describe("objecting entity name tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
     expect(response.status).toEqual(200);
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(1);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
     expect(mockGetObjection).toHaveBeenCalledTimes(1);
     expect(response.text).toContain("What is your full name");
     expect(response.text).toContain(FULL_NAME);
@@ -382,7 +382,7 @@ describe("objecting entity name tests", () => {
 
     expect(response.status).toEqual(500);
     expect(response.text).toContain(ERROR_SCREEN_MESSAGE);
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(1);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
     expect(mockGetObjection).toHaveBeenCalledTimes(1);
   });
 
@@ -402,7 +402,7 @@ describe("objecting entity name tests", () => {
 
     expect(response.status).toEqual(500);
     expect(response.text).toContain(ERROR_SCREEN_MESSAGE);
-    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(1);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(2);
     expect(mockGetObjection).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/controller/objector.organisation.controller.spec.unit.ts
+++ b/test/controller/objector.organisation.controller.spec.unit.ts
@@ -10,7 +10,7 @@ import request from "supertest";
 import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
 
 import app from "../../src/app";
-import { OBJECTIONS_SESSION_NAME } from "../../src/constants";
+import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTOR } from "../../src/constants";
 import { authenticationMiddleware } from "../../src/middleware/authentication.middleware";
 import { objectionSessionMiddleware } from "../../src/middleware/objection.session.middleware";
 import { sessionMiddleware } from "../../src/middleware/session.middleware";
@@ -19,12 +19,13 @@ import { OBJECTIONS_OBJECTING_ENTITY_NAME, OBJECTIONS_OBJECTOR_ORGANISATION } fr
 import { COOKIE_NAME } from "../../src/utils/properties";
 
 import { objectorOrganisation } from "../../src/validation";
-import { addToObjectionSession } from "../../src/services/objection.session.service";
+import { addToObjectionSession, retrieveFromObjectionSession } from "../../src/services/objection.session.service";
 
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 const mockSessionMiddleware = sessionMiddleware as jest.Mock;
 const mockObjectionSessionMiddleware = objectionSessionMiddleware as jest.Mock;
 const mockSetObjectionSessionValue = addToObjectionSession as jest.Mock;
+const mockRetrieveFromObjectionSession = retrieveFromObjectionSession as jest.Mock;
 
 describe('objector organisation controller tests', () => {
   beforeEach(() => {
@@ -82,9 +83,39 @@ describe('objector organisation controller tests', () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    // expect(mockObjectorOrganisationValidator).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(500);
     expect(mockCreateErrorData).toHaveBeenCalledTimes(1);
     expect(mockCreateErrorData).toThrow(Error("Throw Error on createErrorData"));
   });
+
+  it('should render objector organization page and verify the two radio-buttons', async () => {
+    mockSetObjectionSessionValue.mockReset();
+
+    const response = await request(app)
+      .get(OBJECTIONS_OBJECTOR_ORGANISATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain("myself-or-company");
+    expect(response.text).toContain("client");
+    expect(response.text).not.toContain(ErrorMessages.SELECT_OBJECTOR_ORGANISATION);
+  });
+
+  it('should catch and throw exception when retrieveFromObjectionSession', async () => {
+    mockRetrieveFromObjectionSession.mockReset();
+    mockRetrieveFromObjectionSession.mockImplementation(() => {
+      throw new Error("No Objection Session found in Session");
+    });
+
+    const response = await request(app)
+      .get(OBJECTIONS_OBJECTOR_ORGANISATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(response.status).toEqual(500);
+    expect(mockRetrieveFromObjectionSession).toHaveBeenCalledTimes(1);
+    expect(mockRetrieveFromObjectionSession).toThrow(Error("No Objection Session found in Session"));
+  });
+
 });

--- a/test/controller/objector.organisation.controller.spec.unit.ts
+++ b/test/controller/objector.organisation.controller.spec.unit.ts
@@ -2,6 +2,7 @@ jest.mock("ioredis");
 jest.mock("../../src/middleware/authentication.middleware");
 jest.mock("../../src/middleware/session.middleware");
 jest.mock("../../src/middleware/objection.session.middleware");
+jest.mock("../../src/services/objection.session.service");
 
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
@@ -18,10 +19,12 @@ import { OBJECTIONS_OBJECTING_ENTITY_NAME, OBJECTIONS_OBJECTOR_ORGANISATION } fr
 import { COOKIE_NAME } from "../../src/utils/properties";
 
 import { objectorOrganisation } from "../../src/validation";
+import { addToObjectionSession } from "../../src/services/objection.session.service";
 
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 const mockSessionMiddleware = sessionMiddleware as jest.Mock;
 const mockObjectionSessionMiddleware = objectionSessionMiddleware as jest.Mock;
+const mockSetObjectionSessionValue = addToObjectionSession as jest.Mock;
 
 describe('objector organisation controller tests', () => {
   beforeEach(() => {
@@ -43,6 +46,8 @@ describe('objector organisation controller tests', () => {
   });
 
   it('should render objecting entity name page when option selected', async () => {
+    mockSetObjectionSessionValue.mockReset();
+
     const response = await request(app)
       .post(OBJECTIONS_OBJECTOR_ORGANISATION)
       .set("Referer", "/")

--- a/test/controller/objector.organisation.controller.spec.unit.ts
+++ b/test/controller/objector.organisation.controller.spec.unit.ts
@@ -10,7 +10,7 @@ import request from "supertest";
 import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
 
 import app from "../../src/app";
-import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTOR } from "../../src/constants";
+import { OBJECTIONS_SESSION_NAME } from "../../src/constants";
 import { authenticationMiddleware } from "../../src/middleware/authentication.middleware";
 import { objectionSessionMiddleware } from "../../src/middleware/objection.session.middleware";
 import { sessionMiddleware } from "../../src/middleware/session.middleware";

--- a/views/objecting-entity-name.html
+++ b/views/objecting-entity-name.html
@@ -25,12 +25,9 @@
       <form method="post">
         {{ govukInput({
           label: {
-            text: "What is your full name or the name of your organisation?",
+            text: textFullName,
             isPageHeading: true,
             classes: "govuk-label--xl"
-          },
-          hint: {
-            text: "If you are making an application to object on behalf of someone else, enter your own full name or the name of your organisation."
           },
           id: "fullName",
           name: "fullName",
@@ -44,7 +41,7 @@
           name: "shareIdentity",
           fieldset: {
             legend: {
-              text: "Can we share your name and email address with the company if they request that information?",
+              text: textSharedIdentity,
               isPageHeading: false,
               classes: "govuk-fieldset__legend--m"
             }

--- a/views/objecting-entity-name.html
+++ b/views/objecting-entity-name.html
@@ -8,7 +8,7 @@
 
 {% block backLink %}
   {{ govukBackLink({
-    href: "/strike-off-objections",
+    href: backLink,
     text: "Back"
   }) }}
 {% endblock %}

--- a/views/objecting-entity-name.html
+++ b/views/objecting-entity-name.html
@@ -27,7 +27,7 @@
           label: {
             text: textFullName,
             isPageHeading: true,
-            classes: "govuk-label--xl"
+            classes: "govuk-label--l"
           },
           id: "fullName",
           name: "fullName",

--- a/views/objector-organisation.html
+++ b/views/objector-organisation.html
@@ -40,6 +40,7 @@
             {
               value: "myself-or-company",
               text: "I'm objecting for myself, or a company I work for",
+              checked: isMyselfOrCompanyChecked,
               attributes: {
                 "data-event-id" : "myself-or-company"
               }
@@ -47,6 +48,7 @@
             {
               value: "client",
               text: "I'm objecting on behalf of a client",
+              checked: isClientChecked,
               attributes: {
                 "data-event-id" : "client"
               }


### PR DESCRIPTION
- Added logic that dynamically and based on the feature flag updates the object entity name page. 
- Added dynamic back link from entity name page based on feature flag on/off to point to start now page or the new page
- Added logic to save objector selected when we go back from objector-organisation page on session ExtraData object
- Added Unit tests

Resolves [OBJ-438](https://companieshouse.atlassian.net/browse/OBJ-438)