### PR TITLE
Adding global variable onto the title of the page to successfully track in Matomo

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,17 +16,17 @@ export const SHARE_IDENTITY_FIELD = "shareIdentity";
 export const GENERIC_INFO = "generic";
 export const OBJECTOR_FIELDS = {
   "myself-or-company": {
-    textFullName: "Tell us your name, or the name of the company you work for",
+    objectingEntityNamePageText: "Tell us your name, or the name of the company you work for",
     textSharedIdentity: "Can we share the name and email address with the company if they request that information?",
     backLink: OBJECTIONS_OBJECTOR_ORGANISATION
   },
   "client": {
-    textFullName: "What is the name of your organisation?",
+    objectingEntityNamePageText: "What is the name of your organisation?",
     textSharedIdentity: "Can we share the name of your organisation and your email address with the company if they request that information?",
     backLink: OBJECTIONS_OBJECTOR_ORGANISATION
   },
   [GENERIC_INFO]: {
-    textFullName: "What is your full name or the name of your organisation?",
+    objectingEntityNamePageText: "What is your full name or the name of your organisation?",
     textSharedIdentity: "Can we share your name and email address with the company if they request that information?",
     backLink: STRIKE_OFF_OBJECTIONS
   },

--- a/views/objecting-entity-name.html
+++ b/views/objecting-entity-name.html
@@ -3,7 +3,7 @@
   {% if errorList.length > 0 %}
     Error:
   {% endif %}
-  Your full name or the name of your organisation
+  {{ objectingEntityNamePageText }}
 {% endblock %}
 
 {% block backLink %}
@@ -25,7 +25,7 @@
       <form method="post">
         {{ govukInput({
           label: {
-            text: textFullName,
+            text: objectingEntityNamePageText,
             isPageHeading: true,
             classes: "govuk-label--l"
           },


### PR DESCRIPTION
Adding global variable onto the title of the page to successfully track in Matomo for the dynamic organisation entity name page

Resolves: [BI-7538](https://companieshouse.atlassian.net/browse/BI-7538)