### PR TITLE
Reverting start now button id to 3 to be correct for live env

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -43,7 +43,7 @@
           attributes: {
             id: "start-now",
             "data-event-id": "start-now-button",
-            "onclick": "_paq.push(['trackGoal', 15])"
+            "onclick": "_paq.push(['trackGoal', 3])"
           }
         }) }}
       </form>


### PR DESCRIPTION
Reverting start now button id to 3 to be correct for live env after discussions we had with Rachel Cozens

Resolves: [BI-7681](https://companieshouse.atlassian.net/browse/BI-7681)