### PR TITLE
Ignoring whitespace on objection reason screen

### DIFF
--- a/src/controllers/objecting.entity.name.controller.ts
+++ b/src/controllers/objecting.entity.name.controller.ts
@@ -28,7 +28,7 @@ import {
 import ObjectionCompanyProfile from "../model/objection.company.profile";
 
 const validators = [
-  check(FULL_NAME_FIELD).not().isEmpty().withMessage(ErrorMessages.ENTER_NAME),
+  check(FULL_NAME_FIELD).not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.ENTER_NAME),
   check(SHARE_IDENTITY_FIELD).not().isEmpty().withMessage(ErrorMessages.SELECT_TO_DIVULGE),
 ];
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -6,8 +6,8 @@ import { ErrorMessages } from "../model/error.messages";
 import { OBJECTOR_ORGANISATION, ENTER_INFORMATION } from "../constants";
 
 export const validators = {
-  [OBJECTOR_ORGANISATION]: [check(OBJECTOR_ORGANISATION).not().isEmpty().withMessage(ErrorMessages.SELECT_OBJECTOR_ORGANISATION)],
-  [ENTER_INFORMATION]: [check(ENTER_INFORMATION).not().isEmpty().withMessage(ErrorMessages.EMPTY_REASON)],
+  [OBJECTOR_ORGANISATION]: [check(OBJECTOR_ORGANISATION).not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.SELECT_OBJECTOR_ORGANISATION)],
+  [ENTER_INFORMATION]: [check(ENTER_INFORMATION).not().isEmpty({ ignore_whitespace: true }).withMessage(ErrorMessages.EMPTY_REASON)],
 };
 
 export const createErrorData = (errors: Result, id: string) => {

--- a/test/controller/enter.information.controller.spec.unit.ts
+++ b/test/controller/enter.information.controller.spec.unit.ts
@@ -95,6 +95,21 @@ describe("enter information tests", () => {
     expect(response.text).toContain(ErrorMessages.EMPTY_REASON);
   });
 
+  it("should receive error messages when only whitespace entered", async () => {
+    mockRetrieveFromObjectionSession.mockReset();
+    mockGetObjection.mockReset().mockResolvedValueOnce(mockObjection);
+
+    const response = await request(app).post(OBJECTIONS_ENTER_INFORMATION)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        information: " "
+      });
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain(ErrorMessages.EMPTY_REASON);
+  });
+
   it("should render the page with existing information when present", async () => {
     mockRetrieveFromObjectionSession.mockReset();
     mockGetObjection.mockReset().mockResolvedValueOnce(mockObjectionWithReason);

--- a/test/controller/objecting.entity.name.controller.spec.unit.ts
+++ b/test/controller/objecting.entity.name.controller.spec.unit.ts
@@ -270,6 +270,54 @@ describe("objecting entity name tests", () => {
     expect(response.text).toContain(SELECT_TO_DIVULGE);
   });
 
+  it("should receive error message when whitespace is provided and no divulge option is selected", async () => {
+    const response = await request(app)
+      .post(OBJECTIONS_OBJECTING_ENTITY_NAME)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        fullName: " "
+      });
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain(ENTER_FULL_NAME);
+    expect(response.text).toContain(SELECT_TO_DIVULGE);
+  });
+
+  it("should receive error messages when only whitespace is provided but a yes divulge option is selected", async () => {
+    const response = await request(app)
+      .post(OBJECTIONS_OBJECTING_ENTITY_NAME)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        fullName: " ",
+        shareIdentity: "yes"
+      });
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain(ENTER_FULL_NAME);
+    expect(response.text).not.toContain(SELECT_TO_DIVULGE);
+    expect(response.text).toContain("value=\"yes\" checked");
+    expect(response.text).not.toContain("value=\"no\" checked");
+  });
+
+  it("should receive error messages when only whitespace is provided but a no divulge option is selected", async () => {
+    const response = await request(app)
+      .post(OBJECTIONS_OBJECTING_ENTITY_NAME)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`])
+      .send({
+        fullName: " ",
+        shareIdentity: "no"
+      });
+
+    expect(response.status).toEqual(200);
+    expect(response.text).toContain(ENTER_FULL_NAME);
+    expect(response.text).not.toContain(SELECT_TO_DIVULGE);
+    expect(response.text).toContain("value=\"no\" checked");
+    expect(response.text).not.toContain("value=\"yes\" checked");
+  });
+
   it("should receive error message when no name is provided but a yes divulge option is selected", async () => {
     const response = await request(app)
       .post(OBJECTIONS_OBJECTING_ENTITY_NAME)


### PR DESCRIPTION
Adding Validation to Reason for Objection screen to ignore whitespace when checking for empty text box