### PR TITLE
Changing current research.net survey url link to smart survey link

### DIFF
--- a/views/confirmation.html
+++ b/views/confirmation.html
@@ -29,7 +29,7 @@
             <a href="mailto:enquiries@companieshouse.gov.uk">enquiries@companieshouse.gov.uk</a>.</p>
         <p>We may contact you during the review process if we need more information.</p>
         <p>
-            <a href="https://www.research.net/r/applytoobject-conf">What did you think of this service?</a>
+            <a href="https://www.smartsurvey.co.uk/s/applytoobject-conf/">What did you think of this service?</a>
             (takes 2 minutes)</p>
 
     </div>


### PR DESCRIPTION
Resolves: [BI-8824](https://companieshouse.atlassian.net/browse/BI-8824)

Updating the url for the survey link on the confirmation page to reflect the new survey on smartsurvey.co.uk.