### PR TITLE
DEBT-1724 resolve critical sonar vulnerabilty allowlist urls

### DIFF
--- a/src/utils/request.util.ts
+++ b/src/utils/request.util.ts
@@ -21,7 +21,11 @@ export const getWhitelistedReturnToURL = (returnToUrl: string) => {
   let value: string | null;
   for (const expression of REDIRECTS_WHITELIST) {
     value = extractValueIfPresentFromRequestField(returnToUrl, expression);
-    if (value) {return value;}
+
+    if (value) {
+      logger.info(` ${returnToUrl} has been found in whitelist. redirecting...`);
+      return value;
+    }
   }
   const error = `Return to URL ${returnToUrl} not found in trusted URLs whitelist ${REDIRECTS_WHITELIST}.`;
   logger.error(error);

--- a/test/utils/request.util.spec.unit.ts
+++ b/test/utils/request.util.spec.unit.ts
@@ -1,0 +1,61 @@
+import {
+  STRIKE_OFF_OBJECTIONS_OBJECTING_ENTITY_NAME,
+  STRIKE_OFF_OBJECTIONS_ENTER_INFORMATION,
+  STRIKE_OFF_OBJECTIONS_DOCUMENT_UPLOAD,
+  extractValueIfPresentFromRequestField,
+  getWhitelistedReturnToURL,
+} from "../../src/utils/request.util";
+
+
+import { Templates } from "../../src/model/template.paths";
+import { OBJECTIONS_OBJECTING_ENTITY_NAME, OBJECTIONS_ENTER_INFORMATION, OBJECTIONS_DOCUMENT_UPLOAD } from "../../src/model/page.urls";
+
+const UNKNOWN_URL = "/unknown";
+
+describe("request.util.unit",
+         () => {
+           describe("extractValueIfPresentFromRequestField", () => {
+             it("gets correct return to URL for Objecting Entity page", () => {
+               const returnToUrl = extractValueIfPresentFromRequestField(OBJECTIONS_OBJECTING_ENTITY_NAME,
+                                                                         STRIKE_OFF_OBJECTIONS_OBJECTING_ENTITY_NAME);
+               expect(returnToUrl).toEqual(OBJECTIONS_OBJECTING_ENTITY_NAME);
+             });
+             it("gets correct return to URL for Enter Information page", () => {
+               const returnToUrl = extractValueIfPresentFromRequestField(OBJECTIONS_ENTER_INFORMATION,
+                                                                         STRIKE_OFF_OBJECTIONS_ENTER_INFORMATION);
+               expect(returnToUrl).toEqual(OBJECTIONS_ENTER_INFORMATION);
+             });
+             it("gets correct return to URL for Document Upload page", () => {
+               const returnToUrl = extractValueIfPresentFromRequestField(OBJECTIONS_DOCUMENT_UPLOAD, STRIKE_OFF_OBJECTIONS_DOCUMENT_UPLOAD);
+               expect(returnToUrl).toEqual(OBJECTIONS_DOCUMENT_UPLOAD);
+             });
+             it("returns null if asked to look up an unknown page URL", () => {
+               const returnToUrl = extractValueIfPresentFromRequestField(UNKNOWN_URL, STRIKE_OFF_OBJECTIONS_DOCUMENT_UPLOAD);
+               expect(returnToUrl).toEqual(null);
+             });
+           });
+         });
+
+
+describe("getWhitelistedReturnToURL", () => {
+  it("gets correct return to URL for Objecting Entity page", () => {
+    const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_OBJECTING_ENTITY_NAME);
+    expect(returnToUrl).toEqual(OBJECTIONS_OBJECTING_ENTITY_NAME);
+  });
+
+  it("gets correct return to URL for Enter Information page", () => {
+    const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_ENTER_INFORMATION);
+    expect(returnToUrl).toEqual(OBJECTIONS_ENTER_INFORMATION);
+  });
+
+  it("gets correct return to URL for Document Upload page", () => {
+    const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_DOCUMENT_UPLOAD);
+    expect(returnToUrl).toEqual(OBJECTIONS_DOCUMENT_UPLOAD);
+  });
+  it("errors if asked to look up an unknown page URL", () => {
+    const execution = () => getWhitelistedReturnToURL(UNKNOWN_URL);
+    expect(execution).toThrow("Return to URL /unknown not found in trusted URLs whitelist " +
+    "/\\/strike-off-objections\\/objecting-entity-name/," + "/\\/strike-off-objections\\/document-upload/," + "/\\/strike-off-objections\\/enter-information/.");
+  });
+});
+

--- a/test/utils/request.util.spec.unit.ts
+++ b/test/utils/request.util.spec.unit.ts
@@ -6,8 +6,6 @@ import {
   getWhitelistedReturnToURL,
 } from "../../src/utils/request.util";
 
-
-import { Templates } from "../../src/model/template.paths";
 import { OBJECTIONS_OBJECTING_ENTITY_NAME, OBJECTIONS_ENTER_INFORMATION, OBJECTIONS_DOCUMENT_UPLOAD } from "../../src/model/page.urls";
 
 const UNKNOWN_URL = "/unknown";
@@ -33,29 +31,37 @@ describe("request.util.unit",
                const returnToUrl = extractValueIfPresentFromRequestField(UNKNOWN_URL, STRIKE_OFF_OBJECTIONS_DOCUMENT_UPLOAD);
                expect(returnToUrl).toEqual(null);
              });
+             it("returns null if asked to look up an blank page URL", () => {
+               const returnToUrl = extractValueIfPresentFromRequestField("", STRIKE_OFF_OBJECTIONS_DOCUMENT_UPLOAD);
+               expect(returnToUrl).toEqual(null);
+             });
+           });
+
+
+           describe("getWhitelistedReturnToURL", () => {
+             it("gets correct return to URL for Objecting Entity page", () => {
+               const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_OBJECTING_ENTITY_NAME);
+               expect(returnToUrl).toEqual(OBJECTIONS_OBJECTING_ENTITY_NAME);
+             });
+
+             it("gets correct return to URL for Enter Information page", () => {
+               const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_ENTER_INFORMATION);
+               expect(returnToUrl).toEqual(OBJECTIONS_ENTER_INFORMATION);
+             });
+
+             it("gets correct return to URL for Document Upload page", () => {
+               const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_DOCUMENT_UPLOAD);
+               expect(returnToUrl).toEqual(OBJECTIONS_DOCUMENT_UPLOAD);
+             });
+             it("errors if asked to look up an unknown page URL", () => {
+               const execution = () => getWhitelistedReturnToURL(UNKNOWN_URL);
+               expect(execution).toThrow("Return to URL /unknown not found in trusted URLs whitelist " +
+    "/\\/strike-off-objections\\/objecting-entity-name/," + "/\\/strike-off-objections\\/document-upload/," + "/\\/strike-off-objections\\/enter-information/.");
+             });
+             it("errors if asked to look up an blank page URL", () => {
+               const execution = () => getWhitelistedReturnToURL("");
+               expect(execution).toThrow("Return to URL  not found in trusted URLs whitelist " +
+    "/\\/strike-off-objections\\/objecting-entity-name/," + "/\\/strike-off-objections\\/document-upload/," + "/\\/strike-off-objections\\/enter-information/.");
+             });
            });
          });
-
-
-describe("getWhitelistedReturnToURL", () => {
-  it("gets correct return to URL for Objecting Entity page", () => {
-    const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_OBJECTING_ENTITY_NAME);
-    expect(returnToUrl).toEqual(OBJECTIONS_OBJECTING_ENTITY_NAME);
-  });
-
-  it("gets correct return to URL for Enter Information page", () => {
-    const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_ENTER_INFORMATION);
-    expect(returnToUrl).toEqual(OBJECTIONS_ENTER_INFORMATION);
-  });
-
-  it("gets correct return to URL for Document Upload page", () => {
-    const returnToUrl = getWhitelistedReturnToURL(OBJECTIONS_DOCUMENT_UPLOAD);
-    expect(returnToUrl).toEqual(OBJECTIONS_DOCUMENT_UPLOAD);
-  });
-  it("errors if asked to look up an unknown page URL", () => {
-    const execution = () => getWhitelistedReturnToURL(UNKNOWN_URL);
-    expect(execution).toThrow("Return to URL /unknown not found in trusted URLs whitelist " +
-    "/\\/strike-off-objections\\/objecting-entity-name/," + "/\\/strike-off-objections\\/document-upload/," + "/\\/strike-off-objections\\/enter-information/.");
-  });
-});
-


### PR DESCRIPTION
Resolves [DEBT-1724](https://companieshouse.atlassian.net/browse/DEBT-1724)

Adding tests and log to improve coverage of new `request.utils` class. This was added as part of the SonarQube vulnerability critical fix [DEBT-1732](https://companieshouse.atlassian.net/browse/DEBT-1732) that has been implemented previously as part of the investigation.
