### PR TITLE
DEBT-1752 Fix logic to correctly display the company not found page

### DIFF
--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -89,7 +89,7 @@ const post = async (req: Request, res: Response, next: NextFunction): Promise<vo
   } catch (e) {
     logger.error(`Error fetching company profile for company number ${companyNumber}`);
 
-    if (e.status === 404) {
+    if (e.message.includes("404")) {
       buildError(res, CompanySearchErrorMessages.COMPANY_NOT_FOUND);
     } else {
       return next(e);

--- a/test/controller/company.number.controller.spec.unit.ts
+++ b/test/controller/company.number.controller.spec.unit.ts
@@ -136,10 +136,7 @@ describe("company number lookup tests", () => {
 
   it("should create an error message when company is not found", async () => {
     mockCompanyProfile.mockImplementation(() => {
-      throw {
-        message: COMPANY_NOT_FOUND,
-        status: 404,
-      };
+      throw new Error("status: 404");
     });
 
     const response = await request(app)


### PR DESCRIPTION
Resolves [DEBT-1752](https://companieshouse.atlassian.net/browse/DEBT-1752)

Checks if the error is 404 within the string instead of the status property as it was removed to fix security vulnerabilities