### PR TITLE
Improve accessibility on sign-out page

### DIFF
--- a/views/signout.html
+++ b/views/signout.html
@@ -31,7 +31,7 @@
             errorList: [
                 {
                 text: "Select yes if you want to sign out",
-                href: "#yes"
+                href: "#signout"
                 }
             ]
         }) }}
@@ -42,12 +42,13 @@
     <form action="/strike-off-objections/signout" method="POST">
         {{ govukRadios({
             classes: "govuk-radios--inline",
-            idPrefix: "aignout",
+            idPrefix: "signout",
             name: "signout",
             errorMessage: detailsErrorMsg,
             fieldset: {
                 legend: {
-                    html: "Are you sure you want to sign out?",
+                    text: "Are you sure you want to sign out?",
+                    isPageHeading: true,
                     classes: "govuk-fieldset__legend--l"
                 }
             },


### PR DESCRIPTION
Resolves: [BI-11638](https://companieshouse.atlassian.net/browse/BI-11637)

- Update title to have the a page heading value that will register as h1 heading to prevent h1 missing alert in WAVE.

-  Amend typo in the signout radio id and fix href link in the error message to direct to the correct 'yes' radio attribute when a error is triggered