### PR TITLE
BI-11427- Adding Matomo attribute to sign out link button

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -69,7 +69,7 @@
   <ul class="js-signout" id="navigation">
     <li class="content-email" id="signed-in-user">{{email}}</li>
     <li class="content">
-      <a href="/strike-off-objections/signout" id="user-signout">Sign out</a>
+      <a href="/strike-off-objections/signout" data-event-id="sign-out-button-selected" id="user-signout">Sign out</a>
     </li>
   </ul>
   {% endif %}


### PR DESCRIPTION
Resolves: [BI-11427-](https://companieshouse.atlassian.net/browse/BI-11427) 

- Adding Matomo attribute to sign out button to register in Matomo analytics when sign-out link is pressed