### PR TITLE
Fix/bi 11957 stop unnecessary reports being created

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const SESSION_OBJECTION_ID = "objection_id";
 export const SESSION_OBJECTOR = "objector";
 export const CHANGE_ANSWER_KEY = "change";
 export const SIGNOUT_RETURN_URL_SESSION_KEY = "signout-return-to-url";
+export const PREVIOUSLY_SELECTED_COMPANY = "previously_selected_company";
 
 export const FULL_NAME_FIELD = "fullName";
 export const SHARE_IDENTITY_FIELD = "shareIdentity";

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -5,7 +5,9 @@ import { OBJECTIONS_CONFIRM_COMPANY } from "../model/page.urls";
 import { getCompanyProfile } from "../services/company.profile.service";
 import {
   addCompanyProfileToObjectionSession,
+  addToObjectionSession,
   retrieveAccessTokenFromSession,
+  retrieveFromObjectionSession,
 } from "../services/objection.session.service";
 import logger from "../utils/logger";
 import { check, validationResult } from "express-validator";
@@ -13,6 +15,7 @@ import { CompanySearchErrorMessages } from "../model/error.messages";
 import { createGovUkErrorData, GovUkErrorData } from "../model/govuk.error.data";
 import { Templates } from "../model/template.paths";
 import { ValidationError } from "../model/validation.error";
+import { PREVIOUSLY_SELECTED_COMPANY, SESSION_COMPANY_PROFILE } from "../constants";
 
 const companyNumberFieldName: string = "companyNumber";
 
@@ -83,6 +86,11 @@ const post = async (req: Request, res: Response, next: NextFunction): Promise<vo
     token = retrieveAccessTokenFromSession(session);
 
     const company: ObjectionCompanyProfile = await getCompanyProfile(companyNumber, token);
+
+    const sessionCompanyProfile = retrieveFromObjectionSession(session, SESSION_COMPANY_PROFILE);
+    if (sessionCompanyProfile) {
+      addToObjectionSession(session, PREVIOUSLY_SELECTED_COMPANY, sessionCompanyProfile.companyNumber);
+    }
 
     addCompanyProfileToObjectionSession(session, company);
     return res.redirect(OBJECTIONS_CONFIRM_COMPANY);

--- a/src/controllers/company.number.controller.ts
+++ b/src/controllers/company.number.controller.ts
@@ -87,7 +87,7 @@ const post = async (req: Request, res: Response, next: NextFunction): Promise<vo
 
     const company: ObjectionCompanyProfile = await getCompanyProfile(companyNumber, token);
 
-    const sessionCompanyProfile = retrieveFromObjectionSession(session, SESSION_COMPANY_PROFILE);
+    const sessionCompanyProfile: ObjectionCompanyProfile = retrieveFromObjectionSession(session, SESSION_COMPANY_PROFILE);
     if (sessionCompanyProfile) {
       addToObjectionSession(session, PREVIOUSLY_SELECTED_COMPANY, sessionCompanyProfile.companyNumber);
     }

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -79,7 +79,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const previouslySelectedCompany: string = retrieveFromObjectionSession(session, PREVIOUSLY_SELECTED_COMPANY);
     const companyProfileInSession: ObjectionCompanyProfile = retrieveFromObjectionSession(session, SESSION_COMPANY_PROFILE);
     if (previouslySelectedCompany === companyProfileInSession.companyNumber) {
-      const objectionIdInSession = retrieveFromObjectionSession(session, SESSION_OBJECTION_ID);
+      const objectionIdInSession: string = retrieveFromObjectionSession(session, SESSION_OBJECTION_ID);
       await patchObjection(companyNumber, objectionIdInSession, token, objectionCreate);
       const retrievedObjection: Objection = await getObjection(session);
       objectionId = retrievedObjection.id;

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -78,7 +78,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     const previouslySelectedCompany: string = retrieveFromObjectionSession(session, PREVIOUSLY_SELECTED_COMPANY);
     const companyProfileInSession: ObjectionCompanyProfile = retrieveFromObjectionSession(session, SESSION_COMPANY_PROFILE);
-    if (previouslySelectedCompany === companyProfileInSession.companyNumber) {
+  
+    if (previouslySelectedCompany !== undefined && previouslySelectedCompany === companyProfileInSession.companyNumber ) {
       const objectionIdInSession: string = retrieveFromObjectionSession(session, SESSION_OBJECTION_ID);
       await patchObjection(companyNumber, objectionIdInSession, token, objectionCreate);
       const retrievedObjection: Objection = await getObjection(session);
@@ -96,6 +97,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
+    logger.error("add to objections")
     return res.redirect(OBJECTIONS_ENTER_INFORMATION);
   } catch (e) {
     return next(e);

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -97,7 +97,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     addToObjectionSession(session, SESSION_OBJECTION_ID, objectionId);
-    logger.error("add to objections")
     return res.redirect(OBJECTIONS_ENTER_INFORMATION);
   } catch (e) {
     return next(e);

--- a/src/modules/sdk/objections/types.ts
+++ b/src/modules/sdk/objections/types.ts
@@ -80,11 +80,13 @@ export interface Attachment {
  * @interface
  */
 export interface Objection {
+  id: string,
   attachments: Array<{
     name: string;
   }>,
   created_by: CreatedBy,
   reason?: string;
+  status: ObjectionStatus;
 }
 
 export interface CreatedBy {

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -12,7 +12,7 @@ import { Session } from "@companieshouse/node-session-handler/lib/session/model/
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
 import app from "../../src/app";
-import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTION_ID, PREVIOUSLY_SELECTED_COMPANY, SESSION_COMPANY_PROFILE, SESSION_OBJECTION_CREATE } from "../../src/constants";
+import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTION_ID, SESSION_COMPANY_PROFILE, SESSION_OBJECTION_CREATE } from "../../src/constants";
 import { authenticationMiddleware } from "../../src/middleware/authentication.middleware";
 import { objectionSessionMiddleware } from "../../src/middleware/objection.session.middleware";
 import { sessionMiddleware } from "../../src/middleware/session.middleware";
@@ -31,8 +31,6 @@ import {
   ObjectionCreate,
   ObjectionCreatedResponse,
   ObjectionStatus,
-  patchObjection,
-  Objection
 } from "../../src/modules/sdk/objections";
 import { getLatestGaz1FilingHistoryItem } from "../../src/services/company.filing.history.service";
 import { createNewObjection, getCompanyEligibility, getObjection } from "../../src/services/objection.service";
@@ -46,7 +44,6 @@ import {
 import { COOKIE_NAME } from "../../src/utils/properties";
 
 const OBJECTION_ID = "123456";
-const PREVIOUS_OBJECTION_ID = "54321";
 const ACCESS_TOKEN = "KGGGUYUYJHHVK1234";
 const SESSION: Session = {
   data: {},

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -443,4 +443,4 @@ const dummyCompanyEligibilityIneligibleStruckOff: CompanyEligibility = {
   is_eligible: false,
   eligibility_status: EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF,
 };
-
+});

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -1,4 +1,5 @@
 jest.mock("ioredis");
+jest.mock("../../src/modules/sdk/objections");
 jest.mock("../../src/middleware/authentication.middleware");
 jest.mock("../../src/middleware/session.middleware");
 jest.mock("../../src/services/objection.session.service");
@@ -11,10 +12,11 @@ import { Session } from "@companieshouse/node-session-handler/lib/session/model/
 import { NextFunction, Request, Response } from "express";
 import request from "supertest";
 import app from "../../src/app";
-import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTION_ID } from "../../src/constants";
+import { OBJECTIONS_SESSION_NAME, SESSION_OBJECTION_ID, PREVIOUSLY_SELECTED_COMPANY, SESSION_COMPANY_PROFILE, SESSION_OBJECTION_CREATE } from "../../src/constants";
 import { authenticationMiddleware } from "../../src/middleware/authentication.middleware";
 import { objectionSessionMiddleware } from "../../src/middleware/objection.session.middleware";
 import { sessionMiddleware } from "../../src/middleware/session.middleware";
+import * as objectionsSdk from "../../src/modules/sdk/objections";
 import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
 import {
   OBJECTIONS_CONFIRM_COMPANY,
@@ -28,19 +30,23 @@ import {
   EligibilityStatus,
   ObjectionCreate,
   ObjectionCreatedResponse,
-  ObjectionStatus
+  ObjectionStatus,
+  patchObjection,
+  Objection
 } from "../../src/modules/sdk/objections";
 import { getLatestGaz1FilingHistoryItem } from "../../src/services/company.filing.history.service";
-import { createNewObjection, getCompanyEligibility } from "../../src/services/objection.service";
+import { createNewObjection, getCompanyEligibility, getObjection } from "../../src/services/objection.service";
 import {
   addToObjectionSession,
   retrieveAccessTokenFromSession,
   retrieveCompanyProfileFromObjectionSession,
-  retrieveObjectionCreateFromObjectionSession
+  retrieveObjectionCreateFromObjectionSession,
+  retrieveFromObjectionSession
 } from "../../src/services/objection.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
 
 const OBJECTION_ID = "123456";
+const PREVIOUS_OBJECTION_ID = "54321";
 const ACCESS_TOKEN = "KGGGUYUYJHHVK1234";
 const SESSION: Session = {
   data: {},
@@ -48,7 +54,12 @@ const SESSION: Session = {
 
 const mockGetObjectionSessionValue = retrieveCompanyProfileFromObjectionSession as jest.Mock;
 const mockGetObjectCreate = retrieveObjectionCreateFromObjectionSession as jest.Mock;
-
+const mockGetObjection = getObjection as jest.Mock;
+const mockRetrieveProfileFromSession = retrieveCompanyProfileFromObjectionSession as jest.Mock;
+const mockPatchObjection = objectionsSdk.patchObjection as jest.Mock;
+const mockRetrieveObjectionCreateFromSession = retrieveObjectionCreateFromObjectionSession as jest.Mock;
+const mockRetrieveFromObjectionSession = retrieveFromObjectionSession as jest.Mock;
+const mockRetrieveAccessToken = retrieveAccessTokenFromSession as jest.Mock;
 const mockAuthenticationMiddleware = authenticationMiddleware as jest.Mock;
 mockAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
@@ -106,6 +117,7 @@ describe("confirm company tests", () => {
     expect(response.text).toContain("No notice in The Gazette");
   });
 
+
   it("should call the API to create a new objection then render the enter information page", async () => {
 
     mockGetObjectionSessionValue.mockReset();
@@ -130,6 +142,36 @@ describe("confirm company tests", () => {
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(OBJECTIONS_ENTER_INFORMATION);
   });
+
+
+    
+  it("should call the API to update an objection then render the enter information page", async () => {
+
+    mockGetObjectionSessionValue.mockReset();
+    mockRetrieveProfileFromSession.mockImplementation(() => dummyCompanyProfile2);
+    mockRetrieveObjectionCreateFromSession.mockImplementationOnce(() => dummyObjectionCreate);
+    mockRetrieveFromObjectionSession.mockImplementationOnce(() => dummyCompanyProfile2.companyNumber);
+    mockRetrieveFromObjectionSession.mockImplementationOnce(() => dummyCompanyProfile2);
+    mockRetrieveFromObjectionSession.mockImplementationOnce(() => 'OBJ123');
+    
+    mockGetObjection.mockReturnValueOnce(dummyGaz2RequestedObjectionCreatedResponse);
+    mockRetrieveAccessToken.mockImplementationOnce(()=>  ACCESS_TOKEN);
+  
+    SESSION.data[OBJECTIONS_SESSION_NAME] = {
+      [SESSION_COMPANY_PROFILE]: dummyCompanyProfile2,
+      [SESSION_OBJECTION_CREATE]: dummyObjectionCreate,
+      [SESSION_OBJECTION_ID]: 'OBJ123',
+    };
+
+    const response = await request(app).post(OBJECTIONS_CONFIRM_COMPANY)
+      .set("Referer", "/")
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
+
+    expect(mockPatchObjection).toHaveBeenCalledTimes(1);
+    expect(response.status).toEqual(302);
+    expect(response.header.location).toEqual(OBJECTIONS_ENTER_INFORMATION);
+  });
+
 
   it("should render the notice expired page when an objection is created with the status INELIGIBLE_COMPANY_STRUCK_OFF", async () => {
     mockGetObjectionSessionValue.mockReset();
@@ -307,7 +349,8 @@ describe("confirm company tests", () => {
     expect(response.header.location).toEqual(OBJECTIONS_NOTICE_EXPIRED);
   });
 
-});
+
+
 
 const dummyCompanyProfile: ObjectionCompanyProfile = {
   address: {
@@ -322,6 +365,21 @@ const dummyCompanyProfile: ObjectionCompanyProfile = {
   incorporationDate: "26 June 1872",
 };
 
+
+const dummyCompanyProfile2: ObjectionCompanyProfile = {
+  address: {
+    line_1: "line1",
+    line_2: "line2",
+    postCode: "post code",
+  },
+  companyName: "Bear retail",
+  companyNumber: "05916434",
+  companyStatus: "Active",
+  companyType: "limited",
+  incorporationDate: "26 June 1872",
+};
+
+
 const dummyFilingHistoryItem: FilingHistoryItem = {
   category: "",
   date: "2015-04-14",
@@ -335,10 +393,26 @@ const dummyObjectionCreate: ObjectionCreate = {
   share_identity: false,
 };
 
+
 const dummyOpenObjectionCreatedResponse: ObjectionCreatedResponse = {
   objectionId: OBJECTION_ID,
   objectionStatus: ObjectionStatus.OPEN,
 };
+
+const mockObjection = {
+  attachments: [
+    { id: "ATT001",
+      name: "attachment.jpg",
+    },
+    {
+      id: "ATT002",
+      name: "document.pdf",
+    }],
+  id: "OBJ123",
+  reason: "Owed some money",
+};
+
+
 
 const dummyNoDissolutionActionObjectionCreatedResponse: ObjectionCreatedResponse = {
   objectionId: OBJECTION_ID,
@@ -369,3 +443,4 @@ const dummyCompanyEligibilityIneligibleStruckOff: CompanyEligibility = {
   is_eligible: false,
   eligibility_status: EligibilityStatus.INELIGIBLE_COMPANY_STRUCK_OFF,
 };
+


### PR DESCRIPTION
Resolves: [BI-11957](https://companieshouse.atlassian.net/browse/BI-11957)

- Stop creating new records when a user traverses back to select a company number page, when a company is already present in the cache. 
- Add unit test to cover