### PR TITLE
FS-225 Set npm audit level to "high" in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+audit-level=high


### PR DESCRIPTION
Fixes issue that caused `dependency-check` build step to fail despite only minor issues reported from `npm audit`