### PR TITLE
[FS-290]: fix Jest runtime setup for OpenTelemetry performance dependency

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,9 +22,7 @@ module.exports = {
     }
   },
   globalSetup: "./test/global.setup.ts",
-  moduleNameMapper: {
-    '^axios$': require.resolve('axios'),
-  },
+  setupFiles: ["<rootDir>/test/global.setup.ts"],
   moduleNameMapper: {
     '^@opentelemetry/([^/]+)/(.+)$': '<rootDir>/node_modules/@opentelemetry/$1/build/src/index-$2',
     "^axios$": "axios/dist/node/axios.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -595,16 +595,20 @@
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.8.tgz",
-      "integrity": "sha512-isf0SZH/Prw9lhdkmApai/rU/eAdfBpLLapejajmLMdf5Kpq6kJElfvxRGoBG+uZN9Cz3m3/k2jO2K8JLrX3IQ==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/@companieshouse/node-session-handler/-/node-session-handler-5.2.14.tgz",
+      "integrity": "sha512-QFWeSiE5uZSwoSxQfLAyxYPUvlW8daMpS590Yt0FU1PlJqjCClqrMpKU+wR584VZPCKAD9vpJPHjTO21n9bk8Q==",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/structured-logging-node": "^2.0.4",
+        "@companieshouse/structured-logging-node": "^2.0.13",
         "express-async-handler": "^1.1.4",
         "ioredis": "^4.17.3",
         "msgpack5": "^6.0.2",
         "on-headers": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=11"
       }
     },
     "node_modules/@companieshouse/structured-logging-node": {
@@ -626,29 +630,32 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.13.tgz",
-      "integrity": "sha512-Jpnhi7KPKooEHoYoWXNwvqPcx9+eg+iRr7IkafNmXxW6uve+YaLwefvfn6iVq+5eykAUg7tHDnwoMKsRFs4W8Q==",
+      "version": "4.4.20",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.20.tgz",
+      "integrity": "sha512-x5xMuURVC33Fd1Q0JW9lcZM6ovMUeh2X+m5NlgStLUEslhX4pOi58QKr636B9z+Lb2mWg2Y6xWMUZlQ/2WEkRg==",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/node-session-handler": "~5.2.6",
-        "@companieshouse/structured-logging-node": "~2.0.4",
+        "@companieshouse/node-session-handler": "~5.2.14",
+        "@companieshouse/structured-logging-node": "~2.0.13",
         "crypto": "^1.0.1",
         "express-async-handler": "^1.2.0",
-        "uuid": "^9.0.1"
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@companieshouse/web-security-node/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -3005,9 +3012,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3018,7 +3025,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -4726,14 +4733,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -4752,7 +4759,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -8250,9 +8257,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/test/controller/check.your.answers.controller.spec.unit.ts
+++ b/test/controller/check.your.answers.controller.spec.unit.ts
@@ -15,7 +15,7 @@ import { objectionSessionMiddleware } from "../../src/middleware/objection.sessi
 import { sessionMiddleware } from "../../src/middleware/session.middleware";
 import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
 import { OBJECTIONS_CHECK_YOUR_ANSWERS, OBJECTIONS_CONFIRMATION } from "../../src/model/page.urls";
-import { Objection } from "../../src/modules/sdk/objections";
+import { Objection, ObjectionStatus } from "../../src/modules/sdk/objections";
 import { getObjection, submitObjection } from "../../src/services/objection.service";
 import {
   deleteFromObjectionSession,
@@ -166,6 +166,8 @@ const dummyCompanyProfile: ObjectionCompanyProfile = {
 };
 
 const dummyObjectionShare: Objection = {
+  id: "objection-id-123",
+  status: ObjectionStatus.OPEN,
   attachments: [
     {
       name: "attachment.jpg",
@@ -174,6 +176,7 @@ const dummyObjectionShare: Objection = {
       name: "document.pdf",
     }],
   created_by: {
+    objector: "INDIVIDUAL",
     full_name: "Joe Bloggs",
     share_identity: true
   },
@@ -181,6 +184,8 @@ const dummyObjectionShare: Objection = {
 };
 
 const dummyObjectionDoNotShare: Objection = {
+  id: "objection-id-123",
+  status: ObjectionStatus.OPEN,
   attachments: [
     {
       name: "attachment.jpg",
@@ -189,6 +194,7 @@ const dummyObjectionDoNotShare: Objection = {
       name: "document.pdf",
     }],
   created_by: {
+    objector: "INDIVIDUAL",
     full_name: "No Bloggs",
     share_identity: false
   },

--- a/test/controller/confirm.company.controller.spec.unit.ts
+++ b/test/controller/confirm.company.controller.spec.unit.ts
@@ -386,6 +386,7 @@ describe("confirm company tests", () => {
   };
 
   const dummyObjectionCreate: ObjectionCreate = {
+    objector: "INDIVIDUAL",
     full_name: "Joe Bloggs",
     share_identity: false,
   };
@@ -395,21 +396,6 @@ describe("confirm company tests", () => {
     objectionId: OBJECTION_ID,
     objectionStatus: ObjectionStatus.OPEN,
   };
-
-  const mockObjection = {
-    attachments: [
-      { id: "ATT001",
-        name: "attachment.jpg",
-      },
-      {
-        id: "ATT002",
-        name: "document.pdf",
-      }],
-    id: "OBJ123",
-    reason: "Owed some money",
-  };
-
-
 
   const dummyNoDissolutionActionObjectionCreatedResponse: ObjectionCreatedResponse = {
     objectionId: OBJECTION_ID,

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -1,3 +1,13 @@
+import { performance } from "perf_hooks";
+
+// Needed by @opentelemetry/core in Node test runtime
+if (!globalThis.performance) {
+  Object.defineProperty(globalThis, "performance", {
+    value: performance,
+    writable: true,
+    configurable: true
+  });
+}
 export default () => {
   process.env.ACCOUNT_URL = "http://chs.local";
   process.env.COOKIE_NAME = "cookie_name";

--- a/test/routes/routes.spec.unit.ts
+++ b/test/routes/routes.spec.unit.ts
@@ -15,7 +15,7 @@ import { authenticationMiddleware } from "../../src/middleware/authentication.mi
 import { objectionSessionMiddleware } from "../../src/middleware/objection.session.middleware";
 import { sessionMiddleware } from "../../src/middleware/session.middleware";
 import ObjectionCompanyProfile from "../../src/model/objection.company.profile";
-import { CompanyEligibility, EligibilityStatus, Objection } from "../../src/modules/sdk/objections";
+import { CompanyEligibility, EligibilityStatus, Objection, ObjectionStatus } from "../../src/modules/sdk/objections";
 import { getCompanyEligibility, getObjection } from "../../src/services/objection.service";
 import { retrieveCompanyProfileFromObjectionSession, retrieveFromObjectionSession } from "../../src/services/objection.session.service";
 import { COOKIE_NAME } from "../../src/utils/properties";
@@ -201,6 +201,8 @@ const dummyCompanyProfile: ObjectionCompanyProfile = {
 };
 
 const mockObjection: Objection = {
+  id: "objection-id-123",
+  status: ObjectionStatus.OPEN,
   attachments: [
     {
       name: "attachment.jpg",


### PR DESCRIPTION
- add test runtime polyfill for global performance to fix OpenTelemetry import failures
- update Jest setup/config loading so runtime globals are available before test imports
- resolve "ReferenceError: performance is not defined" across unit test suites
- add required objector field in ObjectionCreate and CreatedBy mocks
- add required id and status fields in Objection mocks
- remove TS2741/TS2739 fixture type mismatches in controller specs
- update package-lock.json and dependencies to address security issues
- https://companieshouse.atlassian.net/browse/FS-290