### PR TITLE
Fix document download redirection security issue

### DIFF
--- a/src/controllers/document.download.landing.controller.ts
+++ b/src/controllers/document.download.landing.controller.ts
@@ -1,7 +1,28 @@
 import { Request, Response } from "express";
-import { DOWNLOAD_PREFIX } from "../model/page.urls";
+import { STRIKE_OFF_OBJECTIONS } from "../model/page.urls";
 import { Templates } from "../model/template.paths";
 import logger from "../utils/logger";
+
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+const requireSafeSegment = (value: string | undefined, paramName: string): string => {
+  if (!value || !SAFE_PATH_SEGMENT.test(value)) {
+    throw new Error("Invalid download path parameter: " + paramName);
+  }
+  return value;
+};
+
+const buildDownloadUrl = (req: Request): string => {
+  const companyId = encodeURIComponent(requireSafeSegment(req.params.companyId, "companyId"));
+  const requestId = encodeURIComponent(requireSafeSegment(req.params.requestId, "requestId"));
+  const attachmentId = encodeURIComponent(requireSafeSegment(req.params.attachmentId, "attachmentId"));
+
+  return STRIKE_OFF_OBJECTIONS
+  + "/company/" + companyId
+  + "/strike-off-objections/" + requestId
+  + "/attachments/" + attachmentId
+  + "/download";
+};
 
 /**
  * GET controller for download attachment landing screen
@@ -9,8 +30,12 @@ import logger from "../utils/logger";
  * @param res
  */
 export const get = (req: Request, res: Response) => {
-  // replaces first match only
-  const url: string = req.originalUrl.replace(DOWNLOAD_PREFIX, "");
-  logger.debug("Download landing page with download url = " + url);
-  return res.render(Templates.DOCUMENT_DOWNLOAD_LANDING_PAGE, { downloadUrl: url });
+  try {
+    const downloadUrl = buildDownloadUrl(req);
+    logger.debug("Download landing page with download url = " + downloadUrl);
+    return res.render(Templates.DOCUMENT_DOWNLOAD_LANDING_PAGE, { downloadUrl });
+  } catch (err) {
+    logger.errorRequest(req, "Rejected unsafe download landing URL");
+    return res.status(400).render(Templates.ERROR);
+  }
 };

--- a/src/controllers/document.download.landing.controller.ts
+++ b/src/controllers/document.download.landing.controller.ts
@@ -5,17 +5,17 @@ import logger from "../utils/logger";
 
 const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
 
-const requireSafeSegment = (value: string | undefined, paramName: string): string => {
-  if (!value || !SAFE_PATH_SEGMENT.test(value)) {
+const requireSafeSegment = (value: string | undefined, paramName: string, minLen: number, maxLen: number): string => {
+  if (!value || !SAFE_PATH_SEGMENT.test(value) || value.length < minLen || value.length > maxLen) {
     throw new Error("Invalid download path parameter: " + paramName);
   }
   return value;
 };
 
 const buildDownloadUrl = (req: Request): string => {
-  const companyId = encodeURIComponent(requireSafeSegment(req.params.companyId, "companyId"));
-  const requestId = encodeURIComponent(requireSafeSegment(req.params.requestId, "requestId"));
-  const attachmentId = encodeURIComponent(requireSafeSegment(req.params.attachmentId, "attachmentId"));
+  const companyId = encodeURIComponent(requireSafeSegment(req.params.companyId, "companyId", 8, 8));
+  const requestId = encodeURIComponent(requireSafeSegment(req.params.requestId, "requestId", 18, 18));
+  const attachmentId = encodeURIComponent(requireSafeSegment(req.params.attachmentId, "attachmentId", 36, 36));
 
   return STRIKE_OFF_OBJECTIONS
   + "/company/" + companyId

--- a/src/controllers/document.download.landing.controller.ts
+++ b/src/controllers/document.download.landing.controller.ts
@@ -35,7 +35,8 @@ export const get = (req: Request, res: Response) => {
     logger.debug("Download landing page with download url = " + downloadUrl);
     return res.render(Templates.DOCUMENT_DOWNLOAD_LANDING_PAGE, { downloadUrl });
   } catch (err) {
-    logger.errorRequest(req, "Rejected unsafe download landing URL");
+    const message = err instanceof Error ? err.message : String(err);
+    logger.errorRequest(req, `Rejected unsafe download landing URL - ${message}`);
     return res.status(400).render(Templates.ERROR);
   }
 };

--- a/test/controller/document.download.landing.controller.spec.unit.ts
+++ b/test/controller/document.download.landing.controller.spec.unit.ts
@@ -73,7 +73,7 @@ describe("document download landing page tests", () => {
     const maliciousUrl = "/strike-off-objections/download/company/CO/strike-off-objections/TESTREQ';confirm(1);a='/attachments/TESTATT/download";
     const response: request.Response = await request(app).get(maliciousUrl)
       .set("Referer", "/")
-      .set("Cookie", [COOKIE_NAME + "=123"]);
+      .set("Cookie", [`${COOKIE_NAME}=123`]);
 
     expect(response.status).toBe(400);
     expect(response.text).toContain("Sorry, there is a problem with the service");

--- a/test/controller/document.download.landing.controller.spec.unit.ts
+++ b/test/controller/document.download.landing.controller.spec.unit.ts
@@ -48,7 +48,7 @@ describe("document download landing page tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
     expect(response.status).toBe(200);
-    expect(response.text).toContain("Document download");
+    expect(response.text).toContain("Your document download will start soon");
   });
 
   it("should not call objection session middleware upon render", async () => {

--- a/test/controller/document.download.landing.controller.spec.unit.ts
+++ b/test/controller/document.download.landing.controller.spec.unit.ts
@@ -26,8 +26,15 @@ mockSessionMiddleware.mockImplementation((req: Request, res: Response, next: Nex
 
 const mockObjectionSessionMiddleware = objectionSessionMiddleware as jest.Mock;
 
-const DOWNLOAD_LANDING_PAGE_URL = "/strike-off-objections/download/company/1234/strike-off-objections/5678/attachments/8888/download";
-const DOWNLOAD_FILE_URL = "/strike-off-objections/company/1234/strike-off-objections/5678/attachments/8888/download";
+const VALID_COMPANY_ID = "12345678";
+const VALID_REQUEST_ID = "OBJ-1F3C-A2E4-5D6B";
+const VALID_ATTACHMENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const DOWNLOAD_LANDING_PAGE_URL = `/strike-off-objections/download/company/${VALID_COMPANY_ID}/strike-off-objections/${VALID_REQUEST_ID}/attachments/${VALID_ATTACHMENT_ID}/download`;
+const DOWNLOAD_FILE_URL = `/strike-off-objections/company/${VALID_COMPANY_ID}/strike-off-objections/${VALID_REQUEST_ID}/attachments/${VALID_ATTACHMENT_ID}/download`;
+
+const landingUrl = (companyId: string, requestId: string, attachmentId: string) =>
+  `/strike-off-objections/download/company/${companyId}/strike-off-objections/${requestId}/attachments/${attachmentId}/download`;
 
 describe("document download landing page tests", () => {
 
@@ -70,5 +77,35 @@ describe("document download landing page tests", () => {
 
     expect(response.status).toBe(400);
     expect(response.text).toContain("Sorry, there is a problem with the service");
+  });
+});
+
+describe("document download landing page — path parameter length validation", () => {
+
+  const cookie = [`${COOKIE_NAME}=123`];
+
+  it.each([
+    ["companyId too short",    "1234567",                           VALID_REQUEST_ID,    VALID_ATTACHMENT_ID],
+    ["companyId too long",     "123456789",                         VALID_REQUEST_ID,    VALID_ATTACHMENT_ID],
+    ["requestId too short",    VALID_COMPANY_ID, "ABC12345678",                          VALID_ATTACHMENT_ID],
+    ["requestId too long",     VALID_COMPANY_ID, "ABC1234567890",                        VALID_ATTACHMENT_ID],
+    ["attachmentId too short", VALID_COMPANY_ID, VALID_REQUEST_ID, "550e8400-e29b-41d4-a716-44665544000"],
+    ["attachmentId too long",  VALID_COMPANY_ID, VALID_REQUEST_ID, "550e8400-e29b-41d4-a716-4466554400000"],
+  ])("should return 400 when %s", async (_label: string, companyId: string, requestId: string, attachmentId: string) => {
+    const response = await request(app)
+      .get(landingUrl(companyId, requestId, attachmentId))
+      .set("Referer", "/")
+      .set("Cookie", cookie);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 200 for all params at exact valid lengths", async () => {
+    const response = await request(app)
+      .get(DOWNLOAD_LANDING_PAGE_URL)
+      .set("Referer", "/")
+      .set("Cookie", cookie);
+
+    expect(response.status).toBe(200);
   });
 });

--- a/test/controller/document.download.landing.controller.spec.unit.ts
+++ b/test/controller/document.download.landing.controller.spec.unit.ts
@@ -58,7 +58,8 @@ describe("document download landing page tests", () => {
       .set("Referer", "/")
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
-    expect(response.text).toContain("<body onload=\"javascript:setTimeout(function(){ window.location = '" + DOWNLOAD_FILE_URL + "';},5000);\">");
+    expect(response.text).toContain("<meta http-equiv=\"refresh\" content=\"5;url=" + DOWNLOAD_FILE_URL + "\">");
+    expect(response.text).not.toContain("onload=");
   });
 
   it("should have a download link on the page", async () => {
@@ -68,5 +69,15 @@ describe("document download landing page tests", () => {
 
     expect(response.text).toContain("<a href=\"" + DOWNLOAD_FILE_URL + "\"");
     expect(response.text).not.toContain("download=\"");
+  });
+
+  it("should reject unsafe path segments", async () => {
+    const maliciousUrl = "/strike-off-objections/download/company/CO/strike-off-objections/TESTREQ';confirm(1);a='/attachments/TESTATT/download";
+    const response: request.Response = await request(app).get(maliciousUrl)
+      .set("Referer", "/")
+      .set("Cookie", [COOKIE_NAME + "=123"]);
+
+    expect(response.status).toBe(400);
+    expect(response.text).toContain("Sorry, there is a problem with the service");
   });
 });

--- a/test/controller/document.download.landing.controller.spec.unit.ts
+++ b/test/controller/document.download.landing.controller.spec.unit.ts
@@ -41,7 +41,7 @@ describe("document download landing page tests", () => {
       .set("Cookie", [`${COOKIE_NAME}=123`]);
 
     expect(response.status).toBe(200);
-    expect(response.text).toContain("Your document download will start soon");
+    expect(response.text).toContain("Document download");
   });
 
   it("should not call objection session middleware upon render", async () => {
@@ -51,15 +51,6 @@ describe("document download landing page tests", () => {
 
     expect(response.status).toBe(200);
     expect(mockObjectionSessionMiddleware).not.toBeCalled();
-  });
-
-  it("should have an auto download set in the html", async () => {
-    const response: request.Response = await request(app).get(DOWNLOAD_LANDING_PAGE_URL)
-      .set("Referer", "/")
-      .set("Cookie", [`${COOKIE_NAME}=123`]);
-
-    expect(response.text).toContain("<meta http-equiv=\"refresh\" content=\"5;url=" + DOWNLOAD_FILE_URL + "\">");
-    expect(response.text).not.toContain("onload=");
   });
 
   it("should have a download link on the page", async () => {

--- a/views/download.html
+++ b/views/download.html
@@ -1,9 +1,5 @@
 {% extends "layout.html" %}
 
-{% block download %}
-<meta http-equiv="refresh" content="5;url={{downloadUrl}}">
-{% endblock %}
-
 {% block pageTitle %}
   Your download should start shortly - GOV.UK
 {% endblock %}
@@ -18,10 +14,10 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Your document download will start soon</h1>
+      <h1 class="govuk-heading-xl">Document download</h1>
       <p class="govuk-body-l">
         <a href="{{downloadUrl}}" class="govuk-link">Click here to download your document</a>
-        if the download does not start in 10 seconds.</p>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/views/download.html
+++ b/views/download.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Download your document - GOV.UK
+  Your download should start shortly - GOV.UK
 {% endblock %}
 
 {% block backLink %}
@@ -14,10 +14,10 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Document download</h1>
+      <h1 class="govuk-heading-xl">Your document download will start soon</h1>
       <p class="govuk-body-l">
-        <a href="{{downloadUrl}}" class="govuk-link">Click here to download your document</a>
-      </p>
+        <a href="{{downloadUrl}}" class="govuk-link" id="download-link">Click here to download your document</a>
+        if the download does not start in 10 seconds.</p>
     </div>
   </div>
 {% endblock %}
@@ -25,5 +25,13 @@
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   <script src="{{assetPath}}/javascripts/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
+  <script>
+    window.GOVUKFrontend.initAll()
+    var downloadLink = document.getElementById('download-link');
+    if (downloadLink) {
+      setTimeout(function() {
+        window.location = downloadLink.getAttribute('href');
+      }, 5000);
+    }
+  </script>
 {% endblock %}

--- a/views/download.html
+++ b/views/download.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Your download should start shortly - GOV.UK
+  Download your document - GOV.UK
 {% endblock %}
 
 {% block backLink %}

--- a/views/download.html
+++ b/views/download.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block download %}
-<body onload="javascript:setTimeout(function(){ window.location = '{{downloadUrl}}';},5000);">
+<meta http-equiv="refresh" content="5;url={{downloadUrl}}">
 {% endblock %}
 
 {% block pageTitle %}


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IE-364

Fix the document download redirection security issue,

In here the change is to construct the url by validating all user inputs in the download url against a safe regex.

