### PR TITLE
Add EnsureSessionCookiePresentMiddleware to fix empty csrf issue

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,7 @@ import  errorHandlers from "./controllers/error.controller";
 import { authenticationMiddleware } from "./middleware/authentication.middleware";
 import { objectionSessionMiddleware } from "./middleware/objection.session.middleware";
 import { serviceAvailabilityMiddleware } from "./middleware/service.availability.middleware";
-import { createSessionMiddleware } from "./middleware/session.middleware";
+import { createSessionMiddleware, createEnsureSessionCookiePresentMiddleware } from "./middleware/session.middleware";
 import { MultipartMiddleware } from "./middleware/multipart.middleware";
 import { commonTemplateVariablesMiddleware } from "./middleware/common.variables.middleware";
 import { ErrorMessages } from "./model/error.messages";
@@ -22,6 +22,7 @@ import { createCsrfProtectionMiddleware, csrfErrorHandler } from "./middleware/c
 const redis = new Redis(CACHE_SERVER);
 const sessionStore = new SessionStore(redis);
 const sessionMiddleware = createSessionMiddleware(sessionStore);
+const ensureSessionCookiePresentMiddleware = createEnsureSessionCookiePresentMiddleware();
 const csrfProtectionMiddleware = createCsrfProtectionMiddleware(sessionStore);
 
 const app = express();
@@ -54,6 +55,7 @@ app.use(express.static(path.join(__dirname, "public")));
 app.use(serviceAvailabilityMiddleware);
 app.use(cookieParser());
 app.use(`${pageURLs.STRIKE_OFF_OBJECTIONS}*`, sessionMiddleware);
+app.use(`${pageURLs.STRIKE_OFF_OBJECTIONS}*`, ensureSessionCookiePresentMiddleware);
 app.use(`${pageURLs.STRIKE_OFF_OBJECTIONS}*`, MultipartMiddleware);
 app.use(`${pageURLs.STRIKE_OFF_OBJECTIONS}*`, csrfProtectionMiddleware);
 app.use(`${pageURLs.STRIKE_OFF_OBJECTIONS}/*`, authenticationMiddleware);

--- a/src/middleware/session.middleware.ts
+++ b/src/middleware/session.middleware.ts
@@ -1,10 +1,14 @@
-import { SessionMiddleware, SessionStore } from "@companieshouse/node-session-handler";
-import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_SECRET } from "../utils/properties";
+import { SessionMiddleware, SessionStore, EnsureSessionCookiePresentMiddleware } from "@companieshouse/node-session-handler";
+import { COOKIE_DOMAIN, COOKIE_NAME, COOKIE_SECRET, COOKIE_SECURE_FLAG } from "../utils/properties";
 
 export const createSessionMiddleware = (sessionStore: SessionStore) => SessionMiddleware({
   cookieDomain: COOKIE_DOMAIN,
   cookieName: COOKIE_NAME,
   cookieSecret: COOKIE_SECRET,
-  cookieSecureFlag: undefined,
+  cookieSecureFlag: COOKIE_SECURE_FLAG !== "0", 
   cookieTimeToLiveInSeconds: undefined,
 }, sessionStore, true);
+
+export const createEnsureSessionCookiePresentMiddleware = () => EnsureSessionCookiePresentMiddleware({
+  cookieName: COOKIE_NAME
+});

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -25,6 +25,8 @@ export const COOKIE_SECRET = getEnvironmentVariable("COOKIE_SECRET");
 
 export const CACHE_SERVER = getEnvironmentVariable("CACHE_SERVER");
 
+export const COOKIE_SECURE_FLAG = getEnvironmentVariable("COOKIE_SECURE_FLAG", "1");
+
 export const SHOW_SERVICE_OFFLINE_PAGE = getEnvironmentVariable("SHOW_SERVICE_OFFLINE_PAGE");
 
 export const LOG_LEVEL = getEnvironmentVariable("LOG_LEVEL", "info");

--- a/test/middleware/session.middleware.spec.unit.ts
+++ b/test/middleware/session.middleware.spec.unit.ts
@@ -1,0 +1,41 @@
+jest.mock("ioredis");
+
+import { Request, Response, NextFunction } from "express";
+import { createEnsureSessionCookiePresentMiddleware } from "../../src/middleware/session.middleware";
+import { COOKIE_NAME } from "../../src/utils/properties";
+
+const middleware = createEnsureSessionCookiePresentMiddleware();
+
+const mockNext: NextFunction = jest.fn();
+const mockRedirect = jest.fn();
+
+const buildReq = (cookieValue?: string): Partial<Request> => ({
+  cookies: cookieValue ? { [COOKIE_NAME]: cookieValue } : {},
+  originalUrl: "/strike-off-objections/company-number",
+  get: jest.fn(),
+});
+
+const buildRes = (): Partial<Response> => ({
+  redirect: mockRedirect as any,
+  header: jest.fn().mockReturnThis() as any,
+});
+
+describe("EnsureSessionCookiePresentMiddleware", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call next() when the session cookie is present", () => {
+    middleware(buildReq("abc123") as Request, buildRes() as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("should redirect when the session cookie is absent", () => {
+    middleware(buildReq() as Request, buildRes() as Response, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(mockRedirect).toHaveBeenCalledWith("/strike-off-objections/company-number");
+  });
+});

--- a/test/mocks/session.middleware.ts
+++ b/test/mocks/session.middleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 
-let sessionMiddlewareNextBehavior: (req: Request, res: Response, next: NextFunction) => void = (req, res, next) => next();
+let sessionMiddlewareNextBehavior: (req: Request, res: Response, next: NextFunction) => void = (_req, _res, next) => next();
 
 export const sessionMock = { session: { data: {} } as Session | undefined };
 export const setSessionMiddlewareNextBehavior = (newBehavior: (req: Request, res: Response, next: NextFunction) => void) => {
@@ -13,5 +13,6 @@ jest.mock("../../src/middleware/session.middleware", () => ({
     req.session = sessionMock.session;
     sessionMiddlewareNextBehavior(req, res, next);
   }),
+  createEnsureSessionCookiePresentMiddleware: jest.fn(() => (_req: any, _res: any, next: () => any) => next()),
 }));
 


### PR DESCRIPTION
The intermittent issue is still there.

Steps to re-produce: 
1) Delete all browsing cookies
2) Go to https://cidev.aws.chdev.org/strike-off-objections
3) Click on Make an objection

the _csrf token in the payload is blank which is causing this issue.

Fix is to use the EnsureSessionCookiePresentMiddleware as mentioned in the 
https://github.com/companieshouse/web-security-node
Readme

This PR will be accompanied by a ecs-service-configs-dev change to set COOKIE_SECURE_FLAG to 1