### PR TITLE
Add dedicated healthcheck path to escape all middlewares

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -52,6 +52,9 @@ app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "html");
 app.use(express.static(path.join(__dirname, "public")));
 
+app.get(`${pageURLs.STRIKE_OFF_OBJECTIONS}/healthcheck`, (_req, res) => {
+  res.set("Cache-Control", "no-store").sendStatus(200);
+});
 app.use(serviceAvailabilityMiddleware);
 app.use(cookieParser());
 app.use(`${pageURLs.STRIKE_OFF_OBJECTIONS}*`, sessionMiddleware);

--- a/test/middleware/service.availability.middleware.spec.unit.ts
+++ b/test/middleware/service.availability.middleware.spec.unit.ts
@@ -83,4 +83,13 @@ describe("Availability tests", () => {
     expect(response.text).toMatch(/Sorry, the service is unavailable/);
   });
 
+  it("should return 200 for healthcheck regardless of service availability flag", async () => {
+  process.env.SHOW_SERVICE_OFFLINE_PAGE = "true";
+
+  const response = await request(app)
+    .get("/strike-off-objections/healthcheck");
+
+  expect(response.status).toEqual(200);
+});
+
 });


### PR DESCRIPTION
When the ensureSessionCookiePresentMiddleware kicks in
https://github.com/companieshouse/strike-off-objections-web/pull/333

it doesn't return a 200 for /strike-off-objections, it returns 302 and then redirects back to the same url which returns 200.

This causes the healthcheck to fail cause it doesn't see a 200 and the build fails.

This pr is to fix that behaviour and add a dedicated healthcheck path before any middleware kicks in.